### PR TITLE
Make require("6to5/register") work with browserify

### DIFF
--- a/lib/6to5/register-browser.js
+++ b/lib/6to5/register-browser.js
@@ -1,0 +1,3 @@
+// Required to safely use 6to5/register within a browserify codebase.
+module.exports = function(){};
+require("./polyfill");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "6to5-node": "./bin/6to5-node",
     "6to5-runtime": "./bin/6to5-runtime"
   },
+  "browser": {
+    "./lib/6to5/register.js": "./lib/6to5/register-browser.js"
+  },
   "keywords": [
     "harmony",
     "classes",

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -1,0 +1,19 @@
+var browserify = require("browserify");
+var assert = require("assert");
+var path = require("path");
+var vm = require("vm");
+
+suite("browserify", function() {
+  test("6to5/register may be used without breaking browserify", function(done) {
+    var bundler = browserify(path.join(__dirname, "fixtures/browserify/register.js"));
+
+    bundler.bundle(function(err, bundle) {
+      if (err) return done(err);
+      assert.ok(bundle.length, "bundle output code");
+
+      // ensure that the code runs without throwing an exception
+      vm.runInNewContext(bundle, {});
+      done();
+    })
+  })
+});

--- a/test/fixtures/browserify/register.js
+++ b/test/fixtures/browserify/register.js
@@ -1,0 +1,3 @@
+require('../../../register')({
+  ignoreRegex: false
+});


### PR DESCRIPTION
Previously, you'd have to create a separate file for using 6to5 with both node and browserify, as the latter wasn't able to properly handle loading 6to5's dependency tree and would crash on attempting to do so.

This change instructs browserify to use `register-browser.js` in place of `register.js`. `register-browser.js` still loads the 6to5 polyfill, but is otherwise ignored.

Thanks! :)