### PR TITLE
Add .es to register extensions

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -208,7 +208,7 @@ result.ast;
 
 ### Require hook
 
-All subsequent files required by node with the extensions `.es6` and `.js` will
+All subsequent files required by node with the extensions `.es6`, `.es` and `.js` will
 be transformed by 6to5. The polyfill specified in [Polyfill](polyfill.md) is
 also required; but this is automatically loaded when using:
 

--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -123,7 +123,7 @@ var hookExtensions = function (_exts) {
   });
 };
 
-hookExtensions([".es6", ".js"]);
+hookExtensions([".es6", ".es", ".js"]);
 
 module.exports = function (opts) {
   // normalise options

--- a/lib/6to5/util.js
+++ b/lib/6to5/util.js
@@ -12,7 +12,7 @@ var _          = require("lodash");
 exports.inherits = util.inherits;
 
 exports.canCompile = function (filename, altExts) {
-  var exts = altExts || [".js", ".jsx", ".es6"];
+  var exts = altExts || [".js", ".jsx", ".es6", ".es"];
   var ext = path.extname(filename);
   return _.contains(exts, ext);
 };

--- a/test/util.js
+++ b/test/util.js
@@ -18,6 +18,10 @@ suite("util", function () {
     assert.ok(util.canCompile("/test.es6"));
     assert.ok(util.canCompile("/scripts/test.es6"));
 
+    assert.ok(util.canCompile("test.es"));
+    assert.ok(util.canCompile("/test.es"));
+    assert.ok(util.canCompile("/scripts/test.es"));
+
     assert.ok(!util.canCompile("test"));
     assert.ok(!util.canCompile("test.css"));
     assert.ok(!util.canCompile("/test.css"));


### PR DESCRIPTION
.es is a known ecmascript file extension and should be handled by the loader
See RFC 4329, 8.2.