### PR TITLE
Add support for React pre v0.12 transform

### DIFF
--- a/lib/6to5/transformation/transformers/react.js
+++ b/lib/6to5/transformation/transformers/react.js
@@ -36,8 +36,13 @@ exports.XJSAttribute = {
   }
 };
 
+var isTag = function(tagName) {
+  return (/^[a-z]|\-/).test(tagName);
+};
+
 exports.XJSOpeningElement = {
-  exit: function (node) {
+  exit: function (node, parent, file) {
+    var reactCompat = file.opts && file.opts.reactCompat;
     var tagExpr = node.name;
     var args = [];
 
@@ -48,10 +53,12 @@ exports.XJSOpeningElement = {
       tagName = tagExpr.value;
     }
 
-    if (tagName && (/[a-z]/.exec(tagName[0]) || tagName.indexOf("-") >= 0)) {
-      args.push(t.literal(tagName));
-    } else {
-      args.push(tagExpr);
+    if (!reactCompat) {
+      if (tagName && isTag(tagName)) {
+        args.push(t.literal(tagName));
+      } else {
+        args.push(tagExpr);
+      }
     }
 
     var props = node.attributes;
@@ -95,6 +102,28 @@ exports.XJSOpeningElement = {
     }
 
     args.push(props);
+
+    if (reactCompat) {
+      if (tagName && isTag(tagName)) {
+        return t.callExpression(
+          t.memberExpression(
+            t.memberExpression(
+              t.identifier('React'),
+              t.identifier('DOM'),
+              false
+            ),
+            tagExpr,
+            t.isLiteral(tagExpr)
+          ),
+          args
+        );
+      } else {
+        return t.callExpression(
+          tagExpr,
+          args
+        );
+      }
+    }
 
     tagExpr = t.memberExpression(t.identifier("React"), t.identifier("createElement"));
     return t.callExpression(tagExpr, args);

--- a/test/fixtures/transformation/react/compat-convert-component/actual.js
+++ b/test/fixtures/transformation/react/compat-convert-component/actual.js
@@ -1,0 +1,3 @@
+var x = <Component foo="bar">
+  <Namespace.Component />
+</Component>

--- a/test/fixtures/transformation/react/compat-convert-component/expected.js
+++ b/test/fixtures/transformation/react/compat-convert-component/expected.js
@@ -1,0 +1,3 @@
+var x = Component({
+  foo: "bar"
+}, Namespace.Component(null));

--- a/test/fixtures/transformation/react/compat-convert-component/options.json
+++ b/test/fixtures/transformation/react/compat-convert-component/options.json
@@ -1,0 +1,3 @@
+{
+  "reactCompat": true
+}

--- a/test/fixtures/transformation/react/compat-convert-tags/actual.js
+++ b/test/fixtures/transformation/react/compat-convert-tags/actual.js
@@ -1,0 +1,1 @@
+var x = <div foo="bar"><font-face></font-face></div>;

--- a/test/fixtures/transformation/react/compat-convert-tags/expected.js
+++ b/test/fixtures/transformation/react/compat-convert-tags/expected.js
@@ -1,0 +1,3 @@
+var x = React.DOM.div({
+  foo: "bar"
+}, React.DOM["font-face"](null));

--- a/test/fixtures/transformation/react/compat-convert-tags/options.json
+++ b/test/fixtures/transformation/react/compat-convert-tags/options.json
@@ -1,0 +1,3 @@
+{
+  "reactCompat": true
+}


### PR DESCRIPTION
Adds an option `reactCompat` to emit code that works with React pre v0.12.

We're looking into using 6to5 for a project at Facebook -- and although we make the library -- the project is stuck for some time on React v0.11 which used a different transform.