### PR TITLE
Replace _.each and for-in with for loop in hot paths

### DIFF
--- a/lib/6to5/generation/buffer.js
+++ b/lib/6to5/generation/buffer.js
@@ -77,10 +77,9 @@ Buffer.prototype.newline = function (i, removeLast) {
     if (this.endsWith("{\n")) i--;
     if (this.endsWith(util.repeat(i, "\n"))) return;
 
-    var self = this;
-    _.times(i, function () {
-      self.newline(null, removeLast);
-    });
+    for (var j = 0; j < i; j++) {
+      this.newline(null, removeLast);
+    }
     return;
   }
 
@@ -121,7 +120,11 @@ Buffer.prototype.endsWith = function (str) {
 Buffer.prototype.isLast = function (cha, trimRight) {
   var buf = this.buf;
   if (trimRight) buf = util.trimRight(buf);
+  var last = _.last(buf);
 
-  var chars = [].concat(cha);
-  return _.contains(chars, _.last(buf));
+  if (_.isArray(cha)) {
+    return _.contains(cha, last);
+  } else {
+    return cha === last;
+  }
 };

--- a/lib/6to5/generation/buffer.js
+++ b/lib/6to5/generation/buffer.js
@@ -61,7 +61,7 @@ Buffer.prototype.space = function () {
 Buffer.prototype.removeLast = function (cha) {
   if (!this.isLast(cha)) return;
 
-  this.buf = this.buf.slice(0, -1);
+  this.buf = this.buf.substr(0, this.buf.length - 1);
   this.position.unshift(cha);
 };
 
@@ -114,13 +114,14 @@ Buffer.prototype._push = function (str) {
 };
 
 Buffer.prototype.endsWith = function (str) {
-  return this.buf.slice(-str.length) === str;
+  var d = this.buf.length - str.length;
+  return d >= 0 && this.buf.lastIndexOf(str) === d;
 };
 
 Buffer.prototype.isLast = function (cha, trimRight) {
   var buf = this.buf;
   if (trimRight) buf = util.trimRight(buf);
-  var last = _.last(buf);
+  var last = buf[buf.length - 1];
 
   if (_.isArray(cha)) {
     return _.contains(cha, last);

--- a/lib/6to5/generation/node/index.js
+++ b/lib/6to5/generation/node/index.js
@@ -6,14 +6,19 @@ var t          = require("../../types");
 var _          = require("lodash");
 
 var find = function (obj, node, parent) {
+  if (!obj) return;
   var result;
 
-  _.each(obj, function (fn, type) {
+  var types = Object.keys(obj);
+  for (var i = 0; i < types.length; i++) {
+    var type = types[i];
+
     if (t["is" + type](node)) {
+      var fn = obj[type];
       result = fn(node, parent);
-      if (result != null) return false;
+      if (result != null) break;
     }
-  });
+  }
 
   return result;
 };
@@ -99,7 +104,13 @@ _.each(Node.prototype, function (fn, key) {
   Node[key] = function (node, parent) {
     var n = new Node(node, parent);
 
-    var args = _.toArray(arguments).slice(2);
+    // Avoid leaking arguments to prevent deoptimization
+    var skipCount = 2;
+    var args = new Array(arguments.length - skipCount);
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i + 2];
+    }
+
     return n[key].apply(n, args);
   };
 });

--- a/lib/6to5/generation/position.js
+++ b/lib/6to5/generation/position.js
@@ -1,33 +1,27 @@
 module.exports = Position;
 
-var _ = require("lodash");
-
 function Position() {
   this.line = 1;
   this.column = 0;
 }
 
 Position.prototype.push = function (str) {
-  var self = this;
-
-  _.each(str, function (cha) {
-    if (cha === "\n") {
-      self.line++;
-      self.column = 0;
+  for (var i = 0; i < str.length; i++) {
+    if (str[i] === "\n") {
+      this.line++;
+      this.column = 0;
     } else {
-      self.column++;
+      this.column++;
     }
-  });
+  }
 };
 
 Position.prototype.unshift = function (str) {
-  var self = this;
-
-  _.each(str, function (cha) {
-    if (cha === "\n") {
-      self.line--;
+  for (var i = 0; i < str.length; i++) {
+    if (str[i] === "\n") {
+      this.line--;
     } else {
-      self.column--;
+      this.column--;
     }
-  });
+  }
 };

--- a/lib/6to5/generation/whitespace.js
+++ b/lib/6to5/generation/whitespace.js
@@ -11,15 +11,18 @@ Whitespace.prototype.getNewlinesBefore = function (node) {
   var startToken;
   var endToken;
   var tokens = this.tokens;
+  var token;
 
-  _.each(tokens, function (token, i) {
+  for (var i = 0; i < tokens.length; i++) {
+    token = tokens[i];
+
     // this is the token this node starts with
     if (node.start === token.start) {
       startToken = tokens[i - 1];
       endToken = token;
-      return false;
+      break;
     }
-  });
+  }
 
   return this.getNewlinesBetween(startToken, endToken);
 };
@@ -28,15 +31,18 @@ Whitespace.prototype.getNewlinesAfter = function (node) {
   var startToken;
   var endToken;
   var tokens = this.tokens;
+  var token;
 
-  _.each(tokens, function (token, i) {
+  for (var i = 0; i < tokens.length; i++) {
+    token = tokens[i];
+
     // this is the token this node ends with
     if (node.end === token.end) {
       startToken = token;
       endToken = tokens[i + 1];
-      return false;
+      break;
     }
-  });
+  }
 
   if (endToken.type.type === "eof") {
     return 1;

--- a/lib/6to5/traverse/index.js
+++ b/lib/6to5/traverse/index.js
@@ -8,11 +8,13 @@ function traverse(parent, opts, scope) {
   // falsy node
   if (!parent) return;
 
+  var i, j;
+
   // array of nodes
   if (_.isArray(parent)) {
-    _.each(parent, function (node) {
-      traverse(node, opts, scope);
-    });
+    for (i = 0; i < parent.length; i++) {
+      traverse(parent[i], opts, scope);
+    }
     return;
   }
 
@@ -24,7 +26,7 @@ function traverse(parent, opts, scope) {
 
   var stopped = false;
 
-  for (var i in keys) {
+  for (i = 0; i < keys.length; i++) {
     var key = keys[i];
     var nodes = parent[key];
     if (!nodes) continue;
@@ -108,8 +110,8 @@ function traverse(parent, opts, scope) {
     };
 
     if (_.isArray(nodes)) {
-      for (i in nodes) {
-        handle(nodes, i);
+      for (j = 0; j < nodes.length; j++) {
+        handle(nodes, j);
         if (stopped) return;
       }
 

--- a/lib/6to5/util.js
+++ b/lib/6to5/util.js
@@ -188,7 +188,13 @@ exports.codeFrame = function (lines, lineNumber, colNumber) {
 
 exports.repeat = function (width, cha) {
   cha = cha || " ";
-  return new Array(width + 1).join(cha);
+
+  var result = "";
+  for (var i = 0; i < width; i++) {
+    result += cha;
+  }
+
+  return result;
 };
 
 exports.normaliseAst = function (ast, comments, tokens) {


### PR DESCRIPTION
This is my first PR extracted from experiments in #428.
This alone gives me 24% time improvement (from 212ms on my benchmark to 160ms).