### PR TITLE
add for-of optimization for arrays, toggleable with comment

### DIFF
--- a/lib/6to5/transformation/templates/for-traditional.js
+++ b/lib/6to5/transformation/templates/for-traditional.js
@@ -1,0 +1,3 @@
+for (INIT; INDEX < ARR.length; INDEX++) {
+
+}

--- a/lib/6to5/transformation/transformers/es6-for-of.js
+++ b/lib/6to5/transformation/transformers/es6-for-of.js
@@ -1,29 +1,61 @@
 var util = require("../../util");
 var t    = require("../../types");
 
+function useArrayOptimization(node) {
+  if (!node.leadingComments) {
+    return false;
+  }
+  for (var i = 0; i < node.leadingComments.length; i++) {
+    var comment = node.leadingComments[i].value;
+    if (comment.match(/^\s*6to5: always array\s*$/)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 exports.ForOfStatement = function (node, parent, file, scope) {
   var left = node.left;
+  var value, node2;
+  
+  if (useArrayOptimization(node)) {
+    var arr;
+    var index = file.generateUidIdentifier("i", scope);
+    var init = t.variableDeclaration("var", [t.variableDeclarator(index, t.literal(0))]);
+    if (t.isIdentifier(node.right) || t.isMemberExpression(node.right)) {
+      arr = node.right;
+    } else {
+      arr = scope.generateUidBasedOnNode(node.right, file);
+      init.declarations.push(t.variableDeclarator(arr, node.right));
+    }
+    node2 = util.template("for-traditional", {
+      INIT: init,
+      INDEX: index,
+      ARR: arr,
+    });
+    value = t.memberExpression(arr, index, true);
+  } else {
+    var stepKey = file.generateUidIdentifier("step", scope);
+    node2 = util.template("for-of", {
+      ITERATOR_KEY: file.generateUidIdentifier("iterator", scope),
+      STEP_KEY:     stepKey,
+      OBJECT:       node.right
+    });
+    value = t.memberExpression(stepKey, t.identifier("value"));
+  }
+
   var declar;
-
-  var stepKey   = file.generateUidIdentifier("step", scope);
-  var stepValue = t.memberExpression(stepKey, t.identifier("value"));
-
+  
   if (t.isIdentifier(left)) {
-    declar = t.expressionStatement(t.assignmentExpression("=", left, stepValue));
+    declar = t.expressionStatement(t.assignmentExpression("=", left, value));
   } else if (t.isVariableDeclaration(left)) {
     declar = t.variableDeclaration(left.kind, [
-      t.variableDeclarator(left.declarations[0].id, stepValue)
+      t.variableDeclarator(left.declarations[0].id, value)
     ]);
   } else {
     throw file.errorWithNode(left, "Unknown node type " + left.type + " in ForOfStatement");
   }
-
-  var node2 = util.template("for-of", {
-    ITERATOR_KEY: file.generateUidIdentifier("iterator", scope),
-    STEP_KEY:     stepKey,
-    OBJECT:       node.right
-  });
-
+  
   t.inheritsComments(node2, node);
   t.ensureBlock(node);
 

--- a/test/fixtures/transformation/es6-for-of/array-optimization-computation/actual.js
+++ b/test/fixtures/transformation/es6-for-of/array-optimization-computation/actual.js
@@ -1,0 +1,4 @@
+// 6to5: always array
+for (var i of foo()) {
+  
+}

--- a/test/fixtures/transformation/es6-for-of/array-optimization-computation/expected.js
+++ b/test/fixtures/transformation/es6-for-of/array-optimization-computation/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// 6to5: always array
+for (var _i = 0,
+    _foo = foo(); _i < _foo.length; _i++) {
+  var i = _foo[_i];
+}

--- a/test/fixtures/transformation/es6-for-of/array-optimization-identifier/actual.js
+++ b/test/fixtures/transformation/es6-for-of/array-optimization-identifier/actual.js
@@ -1,0 +1,4 @@
+// 6to5: always array
+for (var i of arr) {
+  
+}

--- a/test/fixtures/transformation/es6-for-of/array-optimization-identifier/expected.js
+++ b/test/fixtures/transformation/es6-for-of/array-optimization-identifier/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// 6to5: always array
+for (var _i = 0; _i < arr.length; _i++) {
+  var i = arr[_i];
+}


### PR DESCRIPTION
proof of concept for #436

problems: 
- doesn't work on array comprehensions
- would like to delete the 6to5: always array comment from output, but they just end up being printed at the bottom of the file. Not sure how this works.