### PR TITLE
Print parens when the member expression object is an update expression

### DIFF
--- a/lib/6to5/generation/generators/expressions.js
+++ b/lib/6to5/generation/generators/expressions.js
@@ -118,7 +118,13 @@ var SCIENTIFIC_NOTATION = /e/i;
 
 exports.MemberExpression = function (node, print) {
   var obj = node.object;
-  print(obj);
+  if (t.isUpdateExpression(obj)) {
+    this.push("(");
+    print(obj);
+    this.push(")");
+  } else {
+    print(obj);
+  }
 
   if (!node.computed && t.isMemberExpression(node.property)) {
     throw new TypeError("Got a MemberExpression for MemberExpression property");

--- a/test/fixtures/generation/types/MemberExpression/actual.js
+++ b/test/fixtures/generation/types/MemberExpression/actual.js
@@ -6,3 +6,6 @@ foo.bar["foo"];
 
 foo["foo"]["bar"];
 foo[test()][bar()];
+
+(foo++).test();
+(+foo).test();

--- a/test/fixtures/generation/types/MemberExpression/expected.js
+++ b/test/fixtures/generation/types/MemberExpression/expected.js
@@ -6,3 +6,6 @@ foo.bar["foo"];
 
 foo["foo"]["bar"];
 foo[test()][bar()];
+
+(foo++).test();
+(+foo).test();


### PR DESCRIPTION
Fix a bug where if the object in a member expression is an update expression the parens would be omitted from the generation.
Example:
`(foo++).test()` would generate `foo++.test` which is a SyntaxError.