### PR TITLE
Optional for-of transformer that puts arrays in fast path

### DIFF
--- a/lib/6to5/transformation/templates/for-of-fast.js
+++ b/lib/6to5/transformation/templates/for-of-fast.js
@@ -1,0 +1,13 @@
+for (var LOOP_OBJECT = OBJECT,
+         IS_ARRAY = Array.isArray(LOOP_OBJECT),
+         INDEX = 0,
+         LOOP_OBJECT = IS_ARRAY ? LOOP_OBJECT : LOOP_OBJECT[Symbol.iterator]();;) {
+  if (IS_ARRAY) {
+    if (INDEX >= LOOP_OBJECT.length) break;
+    ID = LOOP_OBJECT[INDEX++];
+  } else {
+    INDEX = LOOP_OBJECT.next();
+    if (INDEX.done) break;
+    ID = INDEX.value;
+  }
+}

--- a/lib/6to5/transformation/transform.js
+++ b/lib/6to5/transformation/transform.js
@@ -68,6 +68,7 @@ _.each({
   computedPropertyNames:     require("./transformers/es6-computed-property-names"),
   destructuring:             require("./transformers/es6-destructuring"),
   defaultParameters:         require("./transformers/es6-default-parameters"),
+  forOfFast:                 require("./transformers/optional-for-of-fast"),
   forOf:                     require("./transformers/es6-for-of"),
   unicodeRegex:              require("./transformers/es6-unicode-regex"),
   abstractReferences:        require("./transformers/es7-abstract-references"),

--- a/lib/6to5/transformation/transformers/optional-for-of-fast.js
+++ b/lib/6to5/transformation/transformers/optional-for-of-fast.js
@@ -1,0 +1,39 @@
+var util = require("../../util");
+var t    = require("../../types");
+
+exports.optional = true;
+
+exports.ForOfStatement = function (node, parent, file, scope) {
+  var left = node.left;
+  var declar, id;
+
+  if (t.isIdentifier(left)) {
+    id = left;
+  } else if (t.isVariableDeclaration(left)) {
+    id = left.declarations[0].id;
+    declar = t.variableDeclaration(left.kind, [
+      t.variableDeclarator(id)
+    ]);
+  } else  {
+    throw file.errorWithNode(left, "Unknown node type " + left.type + " in ForOfStatement");
+  }
+
+  var node2 = util.template("for-of-fast", {
+    LOOP_OBJECT:  file.generateUidIdentifier("loopObject", scope),
+    IS_ARRAY:     file.generateUidIdentifier("isArray", scope),
+    INDEX:        file.generateUidIdentifier("i", scope),
+    ID:           id,
+    OBJECT:       node.right
+  });
+
+  t.inheritsComments(node2, node);
+  t.ensureBlock(node);
+
+  var block = node2.body;
+  if (declar) {
+    block.body.unshift(declar);
+  }
+  block.body = block.body.concat(node.body.body);
+  
+  return node2;
+};


### PR DESCRIPTION
This PR provides an optional `for-of` transformer that fast-cases arrays. The primary goal is to prevent `for-of` from being a bottleneck in performance sensitive code, which is a problem I've personally had. See #436 for full discussion.

A simple benchmark of summing one million numbers without `forOfFast`. 
```
~/Sources/6to5$ node bin/6to5 foroftest.js | node
traditional x 801 ops/sec ±0.05% (99 runs sampled)
foreach x 25.19 ops/sec ±0.09% (46 runs sampled)
for-of x 6.48 ops/sec ±0.10% (21 runs sampled)
for-of-iter x 6.51 ops/sec ±0.12% (21 runs sampled)
Fastest is traditional
```

With `forOfFast`:
```
~/Sources/6to5$ node bin/6to5 foroftest.js --optional forOfFast | node
traditional x 804 ops/sec ±0.03% (99 runs sampled)
foreach x 25.70 ops/sec ±0.15% (47 runs sampled)
for-of x 483 ops/sec ±0.05% (97 runs sampled)
for-of-iter x 6.42 ops/sec ±0.06% (21 runs sampled)
Fastest is traditional
```

The primary disadvantage of `forOfFast` is that the code generated is big and ugly; it is expected that `forOfFast` would only be used in production builds. I consider this to supersede #439.
