### PR TITLE
Fix short --whitelist option

### DIFF
--- a/bin/6to5/index.js
+++ b/bin/6to5/index.js
@@ -15,7 +15,7 @@ commander.option("-e, --experimental", "Enable experimental support for proposed
 commander.option("-p, --playground", "Enable playground support");
 
 commander.option("-m, --modules [modules]", "Module formatter type to use [common]", "common");
-commander.option("-w, --whitelist [whitelist]", "Whitelist of transformers to ONLY use", util.list);
+commander.option("-l, --whitelist [whitelist]", "Whitelist of transformers to ONLY use", util.list);
 commander.option("-b, --blacklist [blacklist]", "Blacklist of transformers to NOT use", util.list);
 commander.option("-i, --optional [list]", "List of optional transformers to enable", util.list);
 commander.option("-o, --out-file [out]", "Compile all input files into a single file");


### PR DESCRIPTION
`6to5 -w generators` doesn't work because `-w` is short for
`--watch`. This changes the short option for `--whitelist` to `-l`.

I was also thinking about `-u` instead. I don't have any string preferences for either of them, I just used `-l` because of white**l**ist.

Open for suggestions.