### PR TITLE
remove console.log from react transforms

### DIFF
--- a/lib/6to5/transformation/transformers/react.js
+++ b/lib/6to5/transformation/transformers/react.js
@@ -42,7 +42,6 @@ var isTag = function(tagName) {
 
 exports.XJSOpeningElement = {
   exit: function (node, parent, file) {
-    console.log(node);
     var reactCompat = file.opts.reactCompat;
     var tagExpr = node.name;
     var args = [];


### PR DESCRIPTION
looks like a debugging console.log slipped into a recent commit. This is bubbling up to tools that use 6to5 as a library (in my case 6to5ify) causing a lot of junk output when working with JSX.