### PR TITLE
remove Dict from core aliasable constructors

### DIFF
--- a/lib/6to5/transformation/transformers/optional-core-aliasing.js
+++ b/lib/6to5/transformation/transformers/optional-core-aliasing.js
@@ -14,8 +14,7 @@ var ALIASABLE_CONSTRUCTORS = [
   "Map",
   "WeakMap",
   "Set",
-  "WeakSet",
-  "Dict",
+  "WeakSet"
 ];
 
 exports.optional = true;


### PR DESCRIPTION
https://github.com/6to5/6to5/pull/468 included `Dict` as an aliasable constructor for `coreAliasing`. However, it's a core.js extension (not part of ES6) & and not included in the polyfill.