### PR TITLE
don't print traceback on syntax error in CLI

### DIFF
--- a/bin/6to5/util.js
+++ b/bin/6to5/util.js
@@ -20,7 +20,17 @@ exports.transform = function (filename, code, opts) {
   opts = _.extend(opts || {}, index.opts);
   opts.filename = filename;
 
-  var result = to5.transform(code, opts);
+  var result;
+  try {
+    result = to5.transform(code, opts);
+  } catch(e) {
+    if (e.name === "SyntaxError") {
+      console.error("SyntaxError:", e.message);
+      process.exit(1);
+    } else {
+      throw e;
+    }
+  }
   result.filename = filename;
   result.actual = code;
   return result;


### PR DESCRIPTION
When using the CLI, any syntax error will cause a lengthy traceback message to be printed to the screen. This information is irrelevant to the user. This PR fixes that, so you get

```
$ node bin/6to5 test.js
SyntaxError: test.js: Unexpected token (2:8)
  1  | 
> 2  | for (foo) {}
     |        ^
  3  |
```

instead of

```
$ node bin/6to5 test.js

/home/monsanto/Sources/6to5/lib/6to5/util.js:254
    throw err;
          ^
SyntaxError: test.js: Unexpected token (2:8)
  1  | 
> 2  | for (foo) {}
     |        ^
  3  | 
    at raise (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:345:15)
    at unexpected (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:1823:5)
    at expect (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:1811:18)
    at parseFor (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:2333:5)
    at parseForStatement (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:2153:12)
    at parseStatement (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:2030:23)
    at parseTopLevel (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:1995:18)
    at Object.exports.parse (/home/monsanto/Sources/6to5/node_modules/acorn-6to5/acorn.js:48:12)
    at Object.exports.parse (/home/monsanto/Sources/6to5/lib/6to5/util.js:218:21)
    at File.parse (/home/monsanto/Sources/6to5/lib/6to5/file.js:237:15)
```