### PR TITLE
Add loose transform for tagged template literals

### DIFF
--- a/lib/6to5/file.js
+++ b/lib/6to5/file.js
@@ -24,6 +24,7 @@ File.helpers = [
   "prototype-properties",
   "apply-constructor",
   "tagged-template-literal",
+  "tagged-template-literal-loose",
   "interop-require",
   "to-array",
   "sliced-to-array",

--- a/lib/6to5/transformation/templates/tagged-template-literal-loose.js
+++ b/lib/6to5/transformation/templates/tagged-template-literal-loose.js
@@ -1,0 +1,4 @@
+(function (strings, raw) {
+  strings.raw = raw;
+  return strings;
+});

--- a/lib/6to5/transformation/transformers/es6-template-literals.js
+++ b/lib/6to5/transformation/transformers/es6-template-literals.js
@@ -17,11 +17,14 @@ exports.TaggedTemplateExpression = function (node, parent, file) {
     raw.push(t.literal(elem.value.raw));
   }
 
-  args.push(t.callExpression(file.addHelper("tagged-template-literal"), [
-    t.arrayExpression(strings),
-    t.arrayExpression(raw)
-  ]));
+  strings = t.arrayExpression(strings);
+  raw = t.arrayExpression(raw);
 
+  var template = file.isLoose("templateLiterals") ?
+      "tagged-template-literal-loose" :
+      "tagged-template-literal";
+
+  args.push(t.callExpression(file.addHelper(template), [strings, raw]));
   args = args.concat(quasi.expressions);
 
   return t.callExpression(node.tag, args);


### PR DESCRIPTION
Avoids two `Object.freeze` calls & a `defineProperty`. Any differences in behavior are (silent) bugs in the program anyway, since by spec you are not allowed to modify the input to the tag function.

Performance difference:
```
template literal x 59,940 ops/sec ±0.61% (97 runs sampled)
template literal (loose) x 16,084,529 ops/sec ±1.48% (87 runs sampled)
manual tag call x 17,246,276 ops/sec ±1.22% (93 runs sampled)
```