### PR TITLE
Improve performance of rest parameter.

### DIFF
--- a/lib/6to5/transformation/templates/rest.js
+++ b/lib/6to5/transformation/templates/rest.js
@@ -1,3 +1,3 @@
-for (var KEY = START; KEY < ARGUMENTS.length; KEY++) {
+for (var LEN = ARGUMENTS.length, ARRAY = Array(ARRAY_LEN), KEY = START; KEY < LEN; KEY++) {
   ARRAY[ARRAY_KEY] = ARGUMENTS[KEY];
 }

--- a/lib/6to5/transformation/transformers/es6-rest-parameters.js
+++ b/lib/6to5/transformation/transformers/es6-rest-parameters.js
@@ -14,23 +14,31 @@ exports.Function = function (node, parent, file) {
 
   var start = t.literal(node.params.length);
   var key = file.generateUidIdentifier("key");
+  var len = file.generateUidIdentifier("len");
 
   var arrKey = key;
   if (node.params.length) {
-    arrKey = t.binaryExpression("-", arrKey, start);
+    arrKey = t.binaryExpression("-", key, start);
+  }
+
+  var arrLen = len;
+  if (node.params.length) {
+    arrLen = t.conditionalExpression(
+      t.binaryExpression(">", len, start),
+      t.binaryExpression("-", len, start),
+      t.literal(0)
+    );
   }
 
   node.body.body.unshift(
-    t.variableDeclaration("var", [
-      t.variableDeclarator(rest, t.arrayExpression([]))
-    ]),
-
     util.template("rest", {
       ARGUMENTS: argsId,
       ARRAY_KEY: arrKey,
+      ARRAY_LEN: arrLen,
       START: start,
       ARRAY: rest,
-      KEY: key
+      KEY: key,
+      LEN: len,
     })
   );
 };

--- a/test/fixtures/transformation/es6-rest-parameters/arrow-functions/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/arrow-functions/expected.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var concat = function () {
-  var arrs = [];
-
-  for (var _key = 0; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      arrs = Array(_len),
+      _key = 0; _key < _len; _key++) {
     arrs[_key] = arguments[_key];
   }
 };

--- a/test/fixtures/transformation/es6-rest-parameters/multiple/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/multiple/expected.js
@@ -1,17 +1,17 @@
 "use strict";
 
 var t = function (f) {
-  var items = [];
-
-  for (var _key = 1; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      items = Array(_len > 1 ? _len - 1 : 0),
+      _key = 1; _key < _len; _key++) {
     items[_key - 1] = arguments[_key];
   }
 };
 
 function t(f) {
-  var items = [];
-
-  for (var _key2 = 1; _key2 < arguments.length; _key2++) {
+  for (var _len2 = arguments.length,
+      items = Array(_len2 > 1 ? _len2 - 1 : 0),
+      _key2 = 1; _key2 < _len2; _key2++) {
     items[_key2 - 1] = arguments[_key2];
   }
 }

--- a/test/fixtures/transformation/es6-rest-parameters/single/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/single/expected.js
@@ -1,17 +1,17 @@
 "use strict";
 
 var t = function () {
-  var items = [];
-
-  for (var _key = 0; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      items = Array(_len),
+      _key = 0; _key < _len; _key++) {
     items[_key] = arguments[_key];
   }
 };
 
 function t() {
-  var items = [];
-
-  for (var _key2 = 0; _key2 < arguments.length; _key2++) {
+  for (var _len2 = arguments.length,
+      items = Array(_len2),
+      _key2 = 0; _key2 < _len2; _key2++) {
     items[_key2] = arguments[_key2];
   }
 }


### PR DESCRIPTION
Rather than initing an empty array and filling, create an array of the correct size up-front. Minor gain on chromium, but considerably (~5x) faster in spidermonkey/firefox.

Super awesome that 6to5 is already avoiding slicing arguments so v8 and spidermonkey can optimize. Here is a step further though which further improves the performance/optimization these VMs can achieve.

The only drawback is a slightly increased bytesize of the output. However, minified it's negligible and because it's likely to be repeated, gzip also can take a chop at it.

Example of minified:

```js
// source
function foo(one, ...rest) {
  return [one, rest];
}
// before
function t(a){var b=[];for(var k=1;k<arguments.length;k++)b[k-1]=arguments[k];return[a,b]}
// after
function t(a){for(var l=arguments.length,b=Array(l>1?l-1:0),k=1;k<l;k++)a[k-1]=arguments[k];return[a,b]}
```