### PR TITLE
Use output-file-sync instead of mkdirp

### DIFF
--- a/bin/6to5/dir.js
+++ b/bin/6to5/dir.js
@@ -1,9 +1,9 @@
-var chokidar = require("chokidar");
-var mkdirp   = require("mkdirp");
-var path     = require("path");
-var util     = require("./util");
-var fs       = require("fs");
-var _        = require("lodash");
+var chokidar       = require("chokidar");
+var outputFileSync = require("output-file-sync");
+var path           = require("path");
+var util           = require("./util");
+var fs             = require("fs");
+var _              = require("lodash");
 
 module.exports = function (commander, filenames, opts) {
   if (commander.sourceMapsInline) {
@@ -15,16 +15,13 @@ module.exports = function (commander, filenames, opts) {
 
     var data = util.compile(src, { sourceMapName: dest });
 
-    var up = path.normalize(dest + "/..");
-    mkdirp.sync(up);
-
     if (commander.sourceMaps) {
       var mapLoc = dest + ".map";
       data.code = util.addSourceMappingUrl(data.code, mapLoc);
-      fs.writeFileSync(mapLoc, JSON.stringify(data.map));
+      outputFileSync(mapLoc, JSON.stringify(data.map));
     }
 
-    fs.writeFileSync(dest, data.code);
+    outputFileSync(dest, data.code);
 
     console.log(src + " -> " + dest);
   };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-readdir-recursive": "0.1.0",
     "jshint": "2.5.10",
     "lodash": "2.4.1",
-    "mkdirp": "0.5.0",
+    "output-file-sync": "^1.1.0",
     "private": "0.1.6",
     "regenerator": "0.8.3",
     "regexpu": "0.3.0",

--- a/test/bin.js
+++ b/test/bin.js
@@ -1,15 +1,15 @@
 if (process.env.running_under_istanbul) return;
 
-var readdir = require("fs-readdir-recursive");
-var helper  = require("./_helper");
-var assert  = require("assert");
-var rimraf  = require("rimraf");
-var mkdirp  = require("mkdirp");
-var child   = require("child_process");
-var path    = require("path");
-var chai    = require("chai");
-var fs      = require("fs");
-var _       = require("lodash");
+var readdir        = require("fs-readdir-recursive");
+var helper         = require("./_helper");
+var assert         = require("assert");
+var rimraf         = require("rimraf");
+var outputFileSync = require("output-file-sync");
+var child          = require("child_process");
+var path           = require("path");
+var chai           = require("chai");
+var fs             = require("fs");
+var _              = require("lodash");
 
 var fixtureLoc = __dirname + "/fixtures/bin";
 var tmpLoc = __dirname + "/tmp";
@@ -27,10 +27,7 @@ var readDir = function (loc) {
 
 var saveInFiles = function (files) {
   _.each(files, function (content, filename) {
-    var up = path.normalize(filename + "/..");
-    mkdirp.sync(up);
-
-    fs.writeFileSync(filename, content);
+    outputFileSync(filename, content);
   });
 };
 


### PR DESCRIPTION
[output-file-sync](https://github.com/shinnn/output-file-sync):

> Synchronously write a file and create its ancestor directories if needed

It exactly meets our requirements.
