### PR TITLE
Improve performance of rest parameter.

### DIFF
--- a/lib/6to5/transformation/templates/rest.js
+++ b/lib/6to5/transformation/templates/rest.js
@@ -1,3 +1,3 @@
-for (var KEY = START; KEY < ARGUMENTS.length; KEY++) {
+for (var LEN = ARGUMENTS.length, ARRAY = Array(ARRAY_LEN), KEY = START; KEY < LEN; KEY++) {
   ARRAY[ARRAY_KEY] = ARGUMENTS[KEY];
 }

--- a/lib/6to5/transformation/transformers/es6-rest-parameters.js
+++ b/lib/6to5/transformation/transformers/es6-rest-parameters.js
@@ -16,26 +16,34 @@ exports.Function = function (node, parent, file) {
 
   var start = t.literal(node.params.length);
   var key = file.generateUidIdentifier("key");
+  var len = file.generateUidIdentifier("len");
 
   var arrKey = key;
   if (node.params.length) {
     // this method has additional params, so we need to subtract
     // the index of the current argument position from the
     // position in the array that we want to populate
-    arrKey = t.binaryExpression("-", arrKey, start);
+    arrKey = t.binaryExpression("-", key, start);
+  }
+
+  var arrLen = len;
+  if (node.params.length) {
+    arrLen = t.conditionalExpression(
+      t.binaryExpression(">", len, start),
+      t.binaryExpression("-", len, start),
+      t.literal(0)
+    );
   }
 
   node.body.body.unshift(
-    t.variableDeclaration("var", [
-      t.variableDeclarator(rest, t.arrayExpression([]))
-    ]),
-
     util.template("rest", {
       ARGUMENTS: argsId,
       ARRAY_KEY: arrKey,
+      ARRAY_LEN: arrLen,
       START: start,
       ARRAY: rest,
-      KEY: key
+      KEY: key,
+      LEN: len,
     })
   );
 };

--- a/test/fixtures/transformation/es6-rest-parameters/arrow-functions/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/arrow-functions/expected.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var concat = function () {
-  var arrs = [];
-
-  for (var _key = 0; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      arrs = Array(_len),
+      _key = 0; _key < _len; _key++) {
     arrs[_key] = arguments[_key];
   }
 };

--- a/test/fixtures/transformation/es6-rest-parameters/multiple/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/multiple/expected.js
@@ -1,17 +1,17 @@
 "use strict";
 
 var t = function (f) {
-  var items = [];
-
-  for (var _key = 1; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      items = Array(_len > 1 ? _len - 1 : 0),
+      _key = 1; _key < _len; _key++) {
     items[_key - 1] = arguments[_key];
   }
 };
 
 function t(f) {
-  var items = [];
-
-  for (var _key2 = 1; _key2 < arguments.length; _key2++) {
+  for (var _len2 = arguments.length,
+      items = Array(_len2 > 1 ? _len2 - 1 : 0),
+      _key2 = 1; _key2 < _len2; _key2++) {
     items[_key2 - 1] = arguments[_key2];
   }
 }

--- a/test/fixtures/transformation/es6-rest-parameters/single/expected.js
+++ b/test/fixtures/transformation/es6-rest-parameters/single/expected.js
@@ -1,17 +1,17 @@
 "use strict";
 
 var t = function () {
-  var items = [];
-
-  for (var _key = 0; _key < arguments.length; _key++) {
+  for (var _len = arguments.length,
+      items = Array(_len),
+      _key = 0; _key < _len; _key++) {
     items[_key] = arguments[_key];
   }
 };
 
 function t() {
-  var items = [];
-
-  for (var _key2 = 0; _key2 < arguments.length; _key2++) {
+  for (var _len2 = arguments.length,
+      items = Array(_len2),
+      _key2 = 0; _key2 < _len2; _key2++) {
     items[_key2] = arguments[_key2];
   }
 }


### PR DESCRIPTION
Rather than initing an empty array and filling, create an array of the correct size up-front. Minor gain on chromium, but considerably (~5x) faster in spidermonkey/firefox.

This should be the same as #499, just getting it up in PR form for your convenience.