### PR TITLE
Undefined in LetDeclars

### DIFF
--- a/lib/6to5/transformation/transformers/es6-let-scoping.js
+++ b/lib/6to5/transformation/transformers/es6-let-scoping.js
@@ -56,7 +56,7 @@ exports.Loop = function (node, parent, file, scope) {
 };
 
 exports.BlockStatement = function (block, parent, file, scope) {
-  if (!t.isLoop(parent)) {
+  if (!t.isLoop(parent) && block._letDeclars) {
     var letScoping = new LetScoping(false, block, parent, file, scope);
     letScoping.run();
   }


### PR DESCRIPTION
When something adds prototype extensions (in my case, EmberScript loading ember before es6 transpilation), there's a possibility of nulls leaking into block._letDeclars

I'm not sure this is the best place to fix this...  Just wanted to push this up as a suggestion. 

related:
https://github.com/ember-cli/ember-cli/issues/2999