### PR TITLE
Playground Proposal: Mallet operator

### DIFF
--- a/lib/6to5/transformation/transform.js
+++ b/lib/6to5/transformation/transform.js
@@ -46,6 +46,7 @@ _.each({
   specSetters:               require("./transformers/spec-setters"),
 
   // playground
+  malletOperator:            require("./transformers/playground-mallet-operator"),
   methodBinding:             require("./transformers/playground-method-binding"),
   memoizationOperator:       require("./transformers/playground-memoization-operator"),
   objectGetterMemoization:   require("./transformers/playground-object-getter-memoization"),

--- a/lib/6to5/transformation/transformers/playground-mallet-operator.js
+++ b/lib/6to5/transformation/transformers/playground-mallet-operator.js
@@ -1,0 +1,86 @@
+var t = require("../../types");
+
+var isMallet = function (node) {
+  var is = t.isAssignmentExpression(node) && node.operator === "||=";
+  if (is) {
+    var left = node.left;
+    if (!t.isMemberExpression(left) && !t.isIdentifier(left)) {
+      throw new Error("Expected type MemeberExpression or Identifier");
+    }
+    return true;
+  }
+};
+
+var getObjRef = function (node, nodes, file, scope) {
+  var obj = node.object;
+  if (t.isIdentifier(obj)) return obj;
+
+  var temp = scope.generateUidBasedOnNode(obj, file);
+  nodes.push(t.variableDeclaration("var", [
+    t.variableDeclarator(temp, obj)
+  ]));
+  return temp;
+};
+
+var getPropRef = function (node, nodes, file, scope) {
+  var prop = node.property;
+  var key = t.toComputedKey(node, prop);
+  if (t.isLiteral(key)) return key;
+
+  var temp = scope.generateUidBasedOnNode(prop, file);
+  nodes.push(t.variableDeclaration("var", [
+    t.variableDeclarator(temp, prop)
+  ]));
+  return temp;
+};
+
+var buildAbsoluteRef = function (node, nodes, file, scope) {
+  if (t.isIdentifier(node)) return node;
+
+  var obj = getObjRef(node, nodes, file, scope);
+  var prop = getPropRef(node, nodes, file, scope);
+
+  var computed = node.computed || t.isLiteral(prop);
+  return t.memberExpression(obj, prop, computed);
+};
+
+var buildIsNull = function (node) {
+  return t.binaryExpression("==", node, t.literal(null));
+};
+
+var buildAssignment = function (left, right) {
+  return t.assignmentExpression("=", left, right);
+};
+
+exports.ExpressionStatement = function (node, parent, file, scope) {
+  var expr = node.expression;
+  if (!isMallet(expr)) return;
+
+  var nodes = [];
+  var left = buildAbsoluteRef(expr.left, nodes, file, scope);
+
+  nodes.push(t.ifStatement(
+    buildIsNull(left),
+    t.expressionStatement(buildAssignment(left, expr.right))
+  ));
+
+  return nodes;
+};
+
+exports.AssignmentExpression = function (node, parent, file, scope) {
+  if (t.isExpressionStatement(parent)) return;
+  if (!isMallet(node)) return;
+
+  var nodes = [];
+  var left = buildAbsoluteRef(node.left, nodes, file, scope);
+
+  nodes.push(t.logicalExpression(
+    "&&",
+    buildIsNull(left),
+    buildAssignment(left, node.right)
+  ));
+
+  nodes.push(left);
+
+  return t.toSequenceExpression(nodes, scope);
+};

--- a/lib/6to5/transformation/transformers/playground-mallet-operator.js
+++ b/lib/6to5/transformation/transformers/playground-mallet-operator.js
@@ -44,8 +44,8 @@ var buildAbsoluteRef = function (node, nodes, file, scope) {
   return t.memberExpression(obj, prop, computed);
 };
 
-var buildIsNull = function (node) {
-  return t.binaryExpression("==", node, t.literal(null));
+var buildIsFalsey = function (node) {
+  return t.unaryExpression("!", node, true);
 };
 
 var buildAssignment = function (left, right) {
@@ -60,7 +60,7 @@ exports.ExpressionStatement = function (node, parent, file, scope) {
   var left = buildAbsoluteRef(expr.left, nodes, file, scope);
 
   nodes.push(t.ifStatement(
-    buildIsNull(left),
+    buildIsFalsey(left),
     t.expressionStatement(buildAssignment(left, expr.right))
   ));
 
@@ -76,7 +76,7 @@ exports.AssignmentExpression = function (node, parent, file, scope) {
 
   nodes.push(t.logicalExpression(
     "&&",
-    buildIsNull(left),
+    buildIsFalsey(left),
     buildAssignment(left, node.right)
   ));
 

--- a/test/fixtures/transformation/playground/mallet-operator/actual.js
+++ b/test/fixtures/transformation/playground/mallet-operator/actual.js
@@ -1,0 +1,17 @@
+obj ||= {};
+
+obj.x ||= 2;
+
+console.log(obj.x ||= 2);
+
+obj.x.x ||= 2;
+
+console.log(obj.x.x ||= 2);
+
+obj[x()] ||= 2;
+
+console.log(obj[x()] ||= 2);
+
+obj[y()][x()] ||= 2;
+
+console.log(obj[y()][x()] ||= 2);

--- a/test/fixtures/transformation/playground/mallet-operator/exec.js
+++ b/test/fixtures/transformation/playground/mallet-operator/exec.js
@@ -28,10 +28,24 @@ assert.equal(obj.x ||= 2, 2);
 
 obj = { x: false }
 obj.x ||= 2;
-assert.equal(obj.x, false);
+assert.equal(obj.x, 2);
 
 obj = { x: false }
-assert.equal(obj.x ||= 2, false);
+assert.equal(obj.x ||= 2, 2);
+
+obj = { x: '' }
+obj.x ||= 2;
+assert.equal(obj.x, 2);
+
+obj = { x: '' }
+assert.equal(obj.x ||= 2, 2);
+
+obj = { x: 0 }
+obj.x ||= 2;
+assert.equal(obj.x, 2);
+
+obj = { x: 0 }
+assert.equal(obj.x ||= 2, 2);
 
 obj = undefined;
 obj ||= 2;
@@ -54,3 +68,23 @@ assert.equal(obj, 2);
 obj = null;
 assert.equal(obj ||= 2 , 2);
 
+obj = false;
+obj ||= 2;
+assert.equal(obj, 2);
+
+obj = false;
+assert.equal(obj ||= 2 , 2);
+
+obj = '';
+obj ||= 2;
+assert.equal(obj, 2);
+
+obj = '';
+assert.equal(obj ||= 2 , 2);
+
+obj = 0;
+obj ||= 2;
+assert.equal(obj, 2);
+
+obj = 0;
+assert.equal(obj ||= 2 , 2);

--- a/test/fixtures/transformation/playground/mallet-operator/exec.js
+++ b/test/fixtures/transformation/playground/mallet-operator/exec.js
@@ -1,0 +1,56 @@
+var obj = {};
+obj.x ||= 2;
+assert.equal(obj.x, 2);
+
+obj = {};
+assert.equal(obj.x ||= 2, 2);
+
+obj = { x: 1 };
+obj.x ||= 2;
+assert.equal(obj.x, 1);
+
+obj = { x: 1 };
+assert.equal(obj.x ||= 2, 1);
+
+obj = { x: undefined }
+obj.x ||= 2;
+assert.equal(obj.x, 2);
+
+obj = { x: undefined }
+assert.equal(obj.x ||= 2, 2);
+
+obj = { x: null }
+obj.x ||= 2;
+assert.equal(obj.x, 2);
+
+obj = { x: null }
+assert.equal(obj.x ||= 2, 2);
+
+obj = { x: false }
+obj.x ||= 2;
+assert.equal(obj.x, false);
+
+obj = { x: false }
+assert.equal(obj.x ||= 2, false);
+
+obj = undefined;
+obj ||= 2;
+assert.equal(obj, 2);
+
+obj = undefined;
+assert.equal(obj ||= 2 , 2);
+
+obj = 1;
+obj ||= 2;
+assert.equal(obj, 1);
+
+obj = 1;
+assert.equal(obj ||= 2 , 1);
+
+obj = null;
+obj ||= 2;
+assert.equal(obj, 2);
+
+obj = null;
+assert.equal(obj ||= 2 , 2);
+

--- a/test/fixtures/transformation/playground/mallet-operator/expected.js
+++ b/test/fixtures/transformation/playground/mallet-operator/expected.js
@@ -1,29 +1,29 @@
 "use strict";
 
 var _obj$x2, _x2, _obj$y2, _x4;
-if (obj == null) obj = {};
-if (obj.x == null) obj.x = 2;
+if (!obj) obj = {};
+if (!obj.x) obj.x = 2;
 
 
-console.log((obj.x == null && (obj.x = 2), obj.x));
+console.log((!obj.x && (obj.x = 2), obj.x));
 
 var _obj$x = obj.x;
-if (_obj$x.x == null) _obj$x.x = 2;
+if (!_obj$x.x) _obj$x.x = 2;
 
 
-console.log((_obj$x2 = obj.x, _obj$x2.x == null && (_obj$x2.x = 2), _obj$x2.x));
+console.log((_obj$x2 = obj.x, !_obj$x2.x && (_obj$x2.x = 2), _obj$x2.x));
 
 var _x = x();
 
-if (obj[_x] == null) obj[_x] = 2;
+if (!obj[_x]) obj[_x] = 2;
 
 
-console.log((_x2 = x(), obj[_x2] == null && (obj[_x2] = 2), obj[_x2]));
+console.log((_x2 = x(), !obj[_x2] && (obj[_x2] = 2), obj[_x2]));
 
 var _obj$y = obj[y()];
 var _x3 = x();
 
-if (_obj$y[_x3] == null) _obj$y[_x3] = 2;
+if (!_obj$y[_x3]) _obj$y[_x3] = 2;
 
 
-console.log((_obj$y2 = obj[y()], _x4 = x(), _obj$y2[_x4] == null && (_obj$y2[_x4] = 2), _obj$y2[_x4]));
+console.log((_obj$y2 = obj[y()], _x4 = x(), !_obj$y2[_x4] && (_obj$y2[_x4] = 2), _obj$y2[_x4]));

--- a/test/fixtures/transformation/playground/mallet-operator/expected.js
+++ b/test/fixtures/transformation/playground/mallet-operator/expected.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var _obj$x2, _x2, _obj$y2, _x4;
+if (obj == null) obj = {};
+if (obj.x == null) obj.x = 2;
+
+
+console.log((obj.x == null && (obj.x = 2), obj.x));
+
+var _obj$x = obj.x;
+if (_obj$x.x == null) _obj$x.x = 2;
+
+
+console.log((_obj$x2 = obj.x, _obj$x2.x == null && (_obj$x2.x = 2), _obj$x2.x));
+
+var _x = x();
+
+if (obj[_x] == null) obj[_x] = 2;
+
+
+console.log((_x2 = x(), obj[_x2] == null && (obj[_x2] = 2), obj[_x2]));
+
+var _obj$y = obj[y()];
+var _x3 = x();
+
+if (_obj$y[_x3] == null) _obj$y[_x3] = 2;
+
+
+console.log((_obj$y2 = obj[y()], _x4 = x(), _obj$y2[_x4] == null && (_obj$y2[_x4] = 2), _obj$y2[_x4]));


### PR DESCRIPTION
The mallet operator is similar to the current memoization operator,
except it can be used outside of just objects.

In Ruby, it’s almost the same as `a = a || b`. Note that only `nil` and
`false` are falsey in Ruby. I’ve defined it as `== null`, though that
could be changed to any JS falsey value.