### PR TITLE
Simplify getting absolute reference to variable

### DIFF
--- a/lib/6to5/transformation/helpers/build-binary-assignment-operator-transformer.js
+++ b/lib/6to5/transformation/helpers/build-binary-assignment-operator-transformer.js
@@ -15,10 +15,10 @@ module.exports = function (exports, opts) {
     if (!isAssignment(expr)) return;
 
     var nodes    = [];
-    var exploded = explode(expr.left, nodes, file, scope, true);
+    var absRef = explode(expr.left, nodes, file, scope);
 
     nodes.push(t.expressionStatement(
-      buildAssignment(exploded.ref, opts.build(exploded.uid, expr.right))
+      buildAssignment(absRef, opts.build(absRef, expr.right))
     ));
 
     return nodes;
@@ -29,9 +29,9 @@ module.exports = function (exports, opts) {
     if (!isAssignment(node)) return;
 
     var nodes    = [];
-    var exploded = explode(node.left, nodes, file, scope);
-    nodes.push(opts.build(exploded.uid, node.right));
-    nodes.push(exploded.ref);
+    var absRef = explode(node.left, nodes, file, scope);
+    nodes.push(opts.build(absRef, node.right));
+    nodes.push(absRef);
 
     return t.toSequenceExpression(nodes, scope);
   };

--- a/lib/6to5/transformation/helpers/build-conditional-assignment-operator-transformer.js
+++ b/lib/6to5/transformation/helpers/build-conditional-assignment-operator-transformer.js
@@ -12,11 +12,11 @@ module.exports = function (exports, opts) {
 
     var nodes = [];
 
-    var exploded = explode(expr.left, nodes, file, scope);
+    var absRef = explode(expr.left, nodes, file, scope);
 
     nodes.push(t.ifStatement(
-      opts.build(exploded.uid, file),
-      t.expressionStatement(buildAssignment(exploded.ref, expr.right))
+      opts.build(absRef, file),
+      t.expressionStatement(buildAssignment(absRef, expr.right))
     ));
 
     return nodes;
@@ -27,15 +27,15 @@ module.exports = function (exports, opts) {
     if (!opts.is(node, file)) return;
 
     var nodes    = [];
-    var exploded = explode(node.left, nodes, file, scope);
+    var absRef = explode(node.left, nodes, file, scope);
 
     nodes.push(t.logicalExpression(
       "&&",
-      opts.build(exploded.uid, file),
-      buildAssignment(exploded.ref, node.right)
+      opts.build(absRef, file),
+      buildAssignment(absRef, node.right)
     ));
 
-    nodes.push(exploded.ref);
+    nodes.push(absRef);
 
     return t.toSequenceExpression(nodes, scope);
   };

--- a/lib/6to5/transformation/helpers/explode-assignable-expression.js
+++ b/lib/6to5/transformation/helpers/explode-assignable-expression.js
@@ -1,14 +1,8 @@
 var t = require("../../types");
 
 var getObjRef = function (node, nodes, file, scope) {
-  var ref;
-  if (t.isIdentifier(node)) {
-    ref = node;
-  } else if (t.isMemberExpression(node)) {
-    ref = node.object;
-  } else {
-    throw new Error("We can't explode this node type " + node.type);
-  }
+  var ref = node.object;
+  if(t.isIdentifier(ref)) return ref;
 
   var temp = scope.generateUidBasedOnNode(ref, file);
   nodes.push(t.variableDeclaration("var", [
@@ -29,27 +23,12 @@ var getPropRef = function (node, nodes, file, scope) {
   return temp;
 };
 
-module.exports = function (node, nodes, file, scope, allowedSingleIdent) {
-  var obj;
-  if (t.isIdentifier(node) && allowedSingleIdent) {
-    obj = node;
-  } else {
-    obj = getObjRef(node, nodes, file, scope);
-  }
+module.exports = function (node, nodes, file, scope) {
+  if (t.isIdentifier(node)) return node;
 
-  var ref, uid;
+  var obj = getObjRef(node, nodes, file, scope);
+  var prop = getPropRef(node, nodes, file, scope);
 
-  if (t.isIdentifier(node)) {
-    ref = node;
-    uid = obj;
-  } else {
-    var prop = getPropRef(node, nodes, file, scope);
-    var computed = node.computed || t.isLiteral(prop);
-    uid = ref = t.memberExpression(obj, prop, computed);
-  }
-
-  return {
-    uid: uid,
-    ref: ref
-  };
+  var computed = node.computed || t.isLiteral(prop);
+  return t.memberExpression(obj, prop, computed);
 };


### PR DESCRIPTION
This simplifies the generated code for the following two cases, while still caching deep and computed properties (`x.y.z`, `x[y()]`) to avoid unneeded lookups.

```javascript
// x ||= 2

//before
var _x = x;
if (!_x) x = 2;

//after
if (!x) x = 2
```

```javascript
// x.x ||= 2

//before
var _x = x;
if (!_x.x) _x.x = 2;

//after
if (!x.x) x.x = 2

// x.x ?= 2

//before
var _hasOwn = Object.prototype.hasOwnProperty;
var _x = x;
if (!_hasOwn.call(_x, "x")) _x.x = 2

//after
var _hasOwn = Object.prototype.hasOwnProperty;
if (!_hasOwn.call(x, "x")) x.x = 2
```