### PR TITLE
Move more traversers outside closures

### DIFF
--- a/lib/6to5/transformation/helpers/remap-async-to-generator.js
+++ b/lib/6to5/transformation/helpers/remap-async-to-generator.js
@@ -3,19 +3,21 @@
 var traverse = require("../../traverse");
 var t        = require("../../types");
 
+var traverser = {
+  enter: function (node, parent, scope, context) {
+    if (t.isFunction(node)) context.skip();
+
+    if (t.isAwaitExpression(node)) {
+      node.type = "YieldExpression";
+    }
+  }
+};
+
 module.exports = function (node, callId) {
   node.async = false;
   node.generator = true;
 
-  traverse(node, {
-    enter: function (node, parent, scope, context) {
-      if (t.isFunction(node)) context.skip();
-
-      if (t.isAwaitExpression(node)) {
-        node.type = "YieldExpression";
-      }
-    }
-  });
+  traverse(node, traverser);
 
   var call = t.callExpression(callId, [node]);
 

--- a/lib/6to5/transformation/helpers/replace-supers.js
+++ b/lib/6to5/transformation/helpers/replace-supers.js
@@ -5,6 +5,38 @@ module.exports = ReplaceSupers;
 var traverse = require("../../traverse");
 var t        = require("../../types");
 
+var traverser = {
+  enter: function (node, parent, scope, context, state) {
+    var topLevel = state.topLevel;
+    var self = state.self;
+
+    if (t.isFunction(node) && !t.isArrowFunctionExpression(node)) {
+      // we need to call traverseLevel again so we're context aware
+      self.traverseLevel(node, false);
+      return context.skip();
+    }
+
+    if (t.isProperty(node, { method: true }) || t.isMethodDefinition(node)) {
+      // break on object methods
+      return context.skip();
+    }
+
+    var getThisReference = function () {
+      if (topLevel) {
+        // top level so `this` is the instance
+        return t.thisExpression();
+      } else {
+        // not in the top level so we need to create a reference
+        return self.getThisReference();
+      }
+    };
+
+    var callback = self.specHandle;
+    if (self.isLoose) callback = self.looseHandle;
+    return callback.call(self, getThisReference, node, parent);
+  }
+};
+
 /**
  * Description
  *
@@ -111,36 +143,8 @@ ReplaceSupers.prototype.replace = function () {
  */
 
 ReplaceSupers.prototype.traverseLevel = function (node, topLevel) {
-  var self = this;
-
-  traverse(node, {
-    enter: function (node, parent, scope, context) {
-      if (t.isFunction(node) && !t.isArrowFunctionExpression(node)) {
-        // we need to call traverseLevel again so we're context aware
-        self.traverseLevel(node, false);
-        return context.skip();
-      }
-
-      if (t.isProperty(node, { method: true }) || t.isMethodDefinition(node)) {
-        // break on object methods
-        return context.skip();
-      }
-
-      var getThisReference = function () {
-        if (topLevel) {
-          // top level so `this` is the instance
-          return t.thisExpression();
-        } else {
-          // not in the top level so we need to create a reference
-          return self.getThisReference();
-        }
-      };
-
-      var callback = self.specHandle;
-      if (self.isLoose) callback = self.looseHandle;
-      return callback.call(self, getThisReference, node, parent);
-    }
-  });
+  var state = { self: this, topLevel: topLevel };
+  traverse(node, traverser, null, state);
 };
 
 /**

--- a/lib/6to5/transformation/modules/_default.js
+++ b/lib/6to5/transformation/modules/_default.js
@@ -7,6 +7,78 @@ var util     = require("../../util");
 var t        = require("../../types");
 var _        = require("lodash");
 
+var exportsTraverser = {
+  enter: function (node, parent, scope, context, localExports) {
+    var declar = node && node.declaration;
+    if (t.isExportDeclaration(node) && declar && t.isStatement(declar)) {
+      _.extend(localExports, t.getIds(declar, true));
+    }
+  }
+};
+
+var importsTraverser = {
+  enter: function (node, parent, scope, context, localImports) {
+    if (t.isImportDeclaration(node)) {
+      _.extend(localImports, t.getIds(node, true));
+    }
+  }
+};
+
+var remapTraverser = {
+  enter: function (node, parent, scope, context, state) {
+    var self = state.self;
+    if (t.isUpdateExpression(node) && self.isLocalReference(node.argument, scope)) {
+      context.skip();
+
+      // expand to long file assignment expression
+      var assign = t.assignmentExpression(node.operator[0] + "=", node.argument, t.literal(1));
+
+      // remap this assignment expression
+      var remapped = self.remapExportAssignment(assign);
+
+      // we don't need to change the result
+      if (t.isExpressionStatement(parent) || node.prefix) {
+        return remapped;
+      }
+
+      var nodes = [];
+      nodes.push(remapped);
+
+      var operator;
+      if (node.operator === "--") {
+        operator = "+";
+      } else { // "++"
+        operator = "-";
+      }
+      nodes.push(t.binaryExpression(operator, node.argument, t.literal(1)));
+
+      return t.sequenceExpression(nodes);
+    }
+
+    if (t.isAssignmentExpression(node) && self.isLocalReference(node.left, scope)) {
+      context.skip();
+      return self.remapExportAssignment(node);
+    }
+  }
+};
+
+var collissionsTraverser = {
+  enter: function (node, parent, scope, context, state) {
+    var self = state.self;
+    if (t.isAssignmentExpression(node)) {
+
+      var left = node.left;
+      if (t.isMemberExpression(left)) {
+        while (left.object) left = left.object;
+      }
+
+      self.checkLocalReference(left);
+    } else if (t.isDeclaration(node)) {
+      _.each(t.getIds(node, true), self.checkLocalReference);
+    }
+  }
+};
+
 function DefaultFormatter(file) {
   this.file = file;
 
@@ -18,27 +90,10 @@ function DefaultFormatter(file) {
   //this.checkCollisions();
 }
 
-var exportsTraverser = {
-  enter: function (node, parent, scope, context, localExports) {
-    var declar = node && node.declaration;
-    if (t.isExportDeclaration(node) && declar && t.isStatement(declar)) {
-      _.extend(localExports, t.getIds(declar, true));
-    }
-  }
-};
-
 DefaultFormatter.prototype.getLocalExports = function () {
   var localExports = {};
   traverse(this.file.ast, exportsTraverser, null, localExports);
   return localExports;
-};
-
-var importsTraverser = {
-  enter: function (node, parent, scope, context, localImports) {
-    if (t.isImportDeclaration(node)) {
-      _.extend(localImports, t.getIds(node, true));
-    }
-  }
 };
 
 DefaultFormatter.prototype.getLocalImports = function () {
@@ -47,39 +102,22 @@ DefaultFormatter.prototype.getLocalImports = function () {
   return localImports;
 };
 
-var collissionsTraverser = {
-  enter: function (node, parent, scope, context, check) {
-    if (t.isAssignmentExpression(node)) {
+DefaultFormatter.prototype.isLocalReference = function (node) {
+  var localImports = this.localImports;
+  return t.isIdentifier(node) && _.has(localImports, node.name) && localImports[node.name] !== node;
+};
 
-      var left = node.left;
-      if (t.isMemberExpression(left)) {
-        while (left.object) left = left.object;
-      }
-
-      check(left);
-    } else if (t.isDeclaration(node)) {
-      _.each(t.getIds(node, true), check);
-    }
+DefaultFormatter.prototype.checkLocalReference = function (node) {
+  var file = this.file;
+  if (this.isLocalReference(node)) {
+    throw file.errorWithNode(node, "Illegal assignment of module import");
   }
 };
 
 DefaultFormatter.prototype.checkCollisions = function () {
   // todo: all check export collissions
-
-  var localImports = this.localImports;
-  var file = this.file;
-
-  var isLocalReference = function (node) {
-    return t.isIdentifier(node) && _.has(localImports, node.name) && localImports[node.name] !== node;
-  };
-
-  var check = function (node) {
-    if (isLocalReference(node)) {
-      throw file.errorWithNode(node, "Illegal assignment of module import");
-    }
-  };
-
-  traverse(file.ast, collissionsTraverser, null, check);
+  var state = { self: this };
+  traverse(this.file.ast, collissionsTraverser, null, state);
 };
 
 DefaultFormatter.prototype.remapExportAssignment = function (node) {
@@ -94,51 +132,15 @@ DefaultFormatter.prototype.remapExportAssignment = function (node) {
   );
 };
 
-DefaultFormatter.prototype.remapAssignments = function () {
+DefaultFormatter.prototype.isLocalReference = function (node, scope) {
   var localExports = this.localExports;
-  var self = this;
+  var name = node.name;
+  return t.isIdentifier(node) && localExports[name] && localExports[name] === scope.get(name, true);
+};
 
-  var isLocalReference = function (node, scope) {
-    var name = node.name;
-    return t.isIdentifier(node) && localExports[name] && localExports[name] === scope.get(name, true);
-  };
-
-  traverse(this.file.ast, {
-    enter: function (node, parent, scope, context, isLocalReference) {
-      if (t.isUpdateExpression(node) && isLocalReference(node.argument, scope)) {
-        context.skip();
-
-        // expand to long file assignment expression
-        var assign = t.assignmentExpression(node.operator[0] + "=", node.argument, t.literal(1));
-
-        // remap this assignment expression
-        var remapped = self.remapExportAssignment(assign);
-
-        // we don't need to change the result
-        if (t.isExpressionStatement(parent) || node.prefix) {
-          return remapped;
-        }
-
-        var nodes = [];
-        nodes.push(remapped);
-
-        var operator;
-        if (node.operator === "--") {
-          operator = "+";
-        } else { // "++"
-          operator = "-";
-        }
-        nodes.push(t.binaryExpression(operator, node.argument, t.literal(1)));
-
-        return t.sequenceExpression(nodes);
-      }
-
-      if (t.isAssignmentExpression(node) && isLocalReference(node.left, scope)) {
-        context.skip();
-        return self.remapExportAssignment(node);
-      }
-    }
-  }, null, isLocalReference);
+DefaultFormatter.prototype.remapAssignments = function () {
+  var state = { self: this };
+  traverse(this.file.ast, remapTraverser, null, state);
 };
 
 DefaultFormatter.prototype.getModuleName = function () {

--- a/lib/6to5/transformation/modules/common.js
+++ b/lib/6to5/transformation/modules/common.js
@@ -7,16 +7,19 @@ var traverse         = require("../../traverse");
 var util             = require("../../util");
 var t                = require("../../types");
 
+var traverser = {
+  enter: function (node, parent, scope, context, state) {
+    if (t.isExportDeclaration(node) && !node.default) state.hasNonDefaultExports = true;
+  }
+};
+
 function CommonJSFormatter(file) {
   DefaultFormatter.apply(this, arguments);
 
-  var hasNonDefaultExports = false;
-  traverse(file.ast, {
-    enter: function (node) {
-      if (t.isExportDeclaration(node) && !node.default) hasNonDefaultExports = true;
-    }
-  });
-  this.hasNonDefaultExports = hasNonDefaultExports;
+  var state = { hasNonDefaultExports: false };
+  traverse(file.ast, traverser, null, state);
+
+  this.hasNonDefaultExports = state.hasNonDefaultExports;
 }
 
 util.inherits(CommonJSFormatter, DefaultFormatter);

--- a/lib/6to5/transformation/modules/system.js
+++ b/lib/6to5/transformation/modules/system.js
@@ -9,6 +9,77 @@ var util         = require("../../util");
 var t            = require("../../types");
 var _            = require("lodash");
 
+var runnerSettersTraverser = {
+  enter: function (node, parent, scope, context, state) {
+    if (node._importSource === state.source) {
+      if (t.isVariableDeclaration(node)) {
+        _.each(node.declarations, function (declar) {
+          state.hoistDeclarators.push(t.variableDeclarator(declar.id));
+          state.nodes.push(t.expressionStatement(
+            t.assignmentExpression("=", declar.id, declar.init)
+          ));
+        });
+      } else {
+        state.nodes.push(node);
+      }
+
+      context.remove();
+    }
+  }
+};
+
+var hoistVariablesTraverser = {
+  enter: function (node, parent, scope, context, hoistDeclarators) {
+    if (t.isFunction(node)) {
+      // nothing inside is accessible
+      return context.skip();
+    }
+
+    if (t.isVariableDeclaration(node)) {
+      if (node.kind !== "var" && !t.isProgram(parent)) { // let, const
+        // can't be accessed
+        return;
+      }
+
+      var nodes = [];
+
+      _.each(node.declarations, function (declar) {
+        hoistDeclarators.push(t.variableDeclarator(declar.id));
+        if (declar.init) {
+          // no initializer so we can just hoist it as-is
+          var assign = t.expressionStatement(t.assignmentExpression("=", declar.id, declar.init));
+          nodes.push(assign);
+        }
+      });
+
+      // for (var i in test)
+      // for (var i = 0;;)
+      if (t.isFor(parent)) {
+        if (parent.left === node) {
+          return node.declarations[0].id;
+        }
+
+        if (parent.init === node) {
+          return t.toSequenceExpression(nodes, scope);
+        }
+      }
+
+      return nodes;
+    }
+  }
+};
+
+var hoistFunctionsTraverser = {
+  enter: function (node, parent, scope, context, handlerBody) {
+    if (t.isFunction(node)) context.skip();
+
+    if (t.isFunctionDeclaration(node) || node._blockHoist) {
+      handlerBody.push(node);
+      context.remove();
+    }
+  }
+};
+
 function SystemFormatter(file) {
   this.exportIdentifier  = file.generateUidIdentifier("export");
   this.noInteropRequire = true;
@@ -66,28 +137,12 @@ SystemFormatter.prototype.importSpecifier = function (specifier, node, nodes) {
 SystemFormatter.prototype.buildRunnerSetters = function (block, hoistDeclarators) {
   return t.arrayExpression(_.map(this.ids, function (uid, source) {
     var state = {
+      source: source,
       nodes: [],
       hoistDeclarators: hoistDeclarators
     };
 
-    traverse(block, {
-      enter: function (node, parent, scope, context, state) {
-        if (node._importSource === source) {
-          if (t.isVariableDeclaration(node)) {
-            _.each(node.declarations, function (declar) {
-              state.hoistDeclarators.push(t.variableDeclarator(declar.id));
-              state.nodes.push(t.expressionStatement(
-                t.assignmentExpression("=", declar.id, declar.init)
-              ));
-            });
-          } else {
-            state.nodes.push(node);
-          }
-
-          context.remove();
-        }
-      }
-    }, null, state);
+    traverse(block, runnerSettersTraverser, null, state);
 
     return t.functionExpression(null, [uid], t.blockStatement(state.nodes));
   }));
@@ -116,46 +171,7 @@ SystemFormatter.prototype.transform = function (ast) {
   var returnStatement = handlerBody.pop();
 
   // hoist up all variable declarations
-  traverse(block, {
-    enter: function (node, parent, scope, context, hoistDeclarators) {
-      if (t.isFunction(node)) {
-        // nothing inside is accessible
-        return context.skip();
-      }
-
-      if (t.isVariableDeclaration(node)) {
-        if (node.kind !== "var" && !t.isProgram(parent)) { // let, const
-          // can't be accessed
-          return;
-        }
-
-        var nodes = [];
-
-        _.each(node.declarations, function (declar) {
-          hoistDeclarators.push(t.variableDeclarator(declar.id));
-          if (declar.init) {
-            // no initializer so we can just hoist it as-is
-            var assign = t.expressionStatement(t.assignmentExpression("=", declar.id, declar.init));
-            nodes.push(assign);
-          }
-        });
-
-        // for (var i in test)
-        // for (var i = 0;;)
-        if (t.isFor(parent)) {
-          if (parent.left === node) {
-            return node.declarations[0].id;
-          }
-
-          if (parent.init === node) {
-            return t.toSequenceExpression(nodes, scope);
-          }
-        }
-
-        return nodes;
-      }
-    }
-  }, null, hoistDeclarators);
+  traverse(block, hoistVariablesTraverser, null, hoistDeclarators);
 
   if (hoistDeclarators.length) {
     var hoistDeclar = t.variableDeclaration("var", hoistDeclarators);
@@ -164,16 +180,7 @@ SystemFormatter.prototype.transform = function (ast) {
   }
 
   // hoist up function declarations for circular references
-  traverse(block, {
-    enter: function (node, parent, scope, context, handlerBody) {
-      if (t.isFunction(node)) context.skip();
-
-      if (t.isFunctionDeclaration(node) || node._blockHoist) {
-        handlerBody.push(node);
-        context.remove();
-      }
-    }
-  }, null, handlerBody);
+  traverse(block, hoistFunctionsTraverser, null, handlerBody);
 
   handlerBody.push(returnStatement);
 

--- a/lib/6to5/transformation/transformers/es6-constants.js
+++ b/lib/6to5/transformation/transformers/es6-constants.js
@@ -4,6 +4,17 @@ var traverse = require("../../traverse");
 var t        = require("../../types");
 var _        = require("lodash");
 
+var traverser = {
+  enter: function (child, parent, scope, context, state) {
+    if (child._ignoreConstant) return;
+    if (t.isVariableDeclaration(child)) return;
+
+    if (t.isVariableDeclarator(child) || t.isDeclaration(child) || t.isAssignmentExpression(child)) {
+      state.check(parent, state.getIds(child), scope);
+    }
+  }
+};
+
 exports.Program =
 exports.BlockStatement =
 exports.ForInStatement =
@@ -76,14 +87,5 @@ exports.ForStatement = function (node, parent, scope, context, file) {
     getIds: getIds
   };
 
-  traverse(node, {
-    enter: function (child, parent, scope, context, state) {
-      if (child._ignoreConstant) return;
-      if (t.isVariableDeclaration(child)) return;
-
-      if (t.isVariableDeclarator(child) || t.isDeclaration(child) || t.isAssignmentExpression(child)) {
-        state.check(parent, state.getIds(child), scope);
-      }
-    }
-  }, null, state);
+  traverse(node, traverser, null, state);
 };

--- a/lib/6to5/transformation/transformers/es6-let-scoping.js
+++ b/lib/6to5/transformation/transformers/es6-let-scoping.js
@@ -32,6 +32,34 @@ var standardiseLets = function (declars) {
   }
 };
 
+var letReferenceFunctionTraverser = {
+  enter: function (node, parent, scope, context, state) {
+    // not an identifier so we have no use
+    if (!t.isIdentifier(node)) return;
+
+    // not a direct reference
+    if (!t.isReferenced(node, parent)) return;
+
+    // this scope has a variable with the same name so it couldn't belong
+    // to our let scope
+    if (scope.hasOwn(node.name, true)) return;
+
+    // not a part of our scope
+    if (!state.letReferences[node.name]) return;
+
+    state.closurify = true;
+  }
+};
+
+var letReferenceBlockTraverser = {
+  enter: function (node, parent, scope, context, state) {
+    if (t.isFunction(node)) {
+      traverse(node, letReferenceFunctionTraverser, scope, state);
+      return context.skip();
+    }
+  }
+};
+
 exports.VariableDeclaration = function (node, parent) {
   isLet(node, parent);
 };
@@ -261,32 +289,7 @@ LetScoping.prototype.getLetReferences = function () {
 
   // traverse through this block, stopping on functions and checking if they
   // contain any local let references
-  traverse(this.block, {
-    enter: function (node, parent, scope, context, state) {
-      if (t.isFunction(node)) {
-        traverse(node, {
-          enter: function (node, parent) {
-            // not an identifier so we have no use
-            if (!t.isIdentifier(node)) return;
-
-            // not a direct reference
-            if (!t.isReferenced(node, parent)) return;
-
-            // this scope has a variable with the same name so it couldn't belong
-            // to our let scope
-            if (scope.hasOwn(node.name, true)) return;
-
-            // not a part of our scope
-            if (!state.letReferences[node.name]) return;
-
-            state.closurify = true;
-          }
-        }, scope, state);
-
-        return context.skip();
-      }
-    }
-  }, this.scope, state);
+  traverse(this.block, letReferenceBlockTraverser, this.scope, state);
 
   return state.closurify;
 };


### PR DESCRIPTION
This continues refactoring started in #518.

While I'm in the middle of it, I have a style question: should I define traverser objects next to functions that use them, or at the top?