### PR TITLE
System output tests

### DIFF
--- a/test/fixtures/transformation/es6-modules-system/exports-generator/actual.js
+++ b/test/fixtures/transformation/es6-modules-system/exports-generator/actual.js
@@ -1,0 +1,3 @@
+export function* generator() {
+  yield 1;
+}

--- a/test/fixtures/transformation/es6-modules-system/exports-generator/expected.js
+++ b/test/fixtures/transformation/es6-modules-system/exports-generator/expected.js
@@ -1,0 +1,23 @@
+System.register([], function (_export) {
+  "use strict";
+
+  var generator;
+  _export("generator", generator = regeneratorRuntime.mark(function generator() {
+    return regeneratorRuntime.wrap(function generator$(context$1$0) {
+      while (1) switch (context$1$0.prev = context$1$0.next) {
+        case 0:
+          context$1$0.next = 2;
+          return 1;
+        case 2:
+        case "end":
+          return context$1$0.stop();
+      }
+    }, generator, this);
+  }));
+
+  return {
+    setters: [],
+    execute: function () {
+    }
+  };
+});

--- a/test/fixtures/transformation/es6-modules-system/exports-variable/actual.js
+++ b/test/fixtures/transformation/es6-modules-system/exports-variable/actual.js
@@ -6,3 +6,4 @@ export let foo5;
 export const foo6 = 3;
 export function foo7 () {}
 export class foo8 {}
+foo3 = 5;

--- a/test/fixtures/transformation/es6-modules-system/exports-variable/expected.js
+++ b/test/fixtures/transformation/es6-modules-system/exports-variable/expected.js
@@ -17,6 +17,8 @@ System.register([], function (_export) {
       foo8 = function foo8() {};
 
       _export("foo8", foo8);
+
+      _export("foo3", foo3 = 5);
     }
   };
 });


### PR DESCRIPTION
These are two more output bugs I found running the ES6 Module Loader tests. This includes https://github.com/6to5/6to5/issues/554.

The two issues are that exported variable binding assignments should run the setter function, and that generators should hoist (I believe this is how generators would behave in implementations - let me know if I'm incorrect here).