### PR TITLE
Use $BROWSER with fallbacks for opening browser tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ test-browser:
 	node $(BROWSERIFY_CMD) -e test/_browser.js >dist/6to5-test.js
 	rm -rf templates.json tests.json
 
-	test -n "`which open`" && open test/browser.html
+	if [ -n $$BROWSER ]; then $$BROWSER test/browser.html; \
+	elif which xdg-open > /dev/null; then xdg-open 'test/browser.html'; \
+	elif which gnome-open > /dev/null; then gnome-open 'test/browser.html'; \
+	elif which open > /dev/null; then open 'test/browser.html'; fi \
 
 publish:
 	git pull --rebase


### PR DESCRIPTION
The use of `open` causes `test-browser` to fail on Linux, testing for `open` will be true, but `open` is not semantically the same as `open` on OSX, the equivalent on a Linux desktop would typically be `xgd-open` or maybe even `gnome-open`.

Just for good measure while i was at it, I added `$BROWSER` as an option, so that one has the option by doing something like the following
`BROWSER=firefox make test-browser`
`BROWSER=google-chrome make test-browser`
`BROWSER=google-chrome make test-browser`