### PR TITLE
Test for circular bindings updates

### DIFF
--- a/test/fixtures/transformation/es6-modules-system/exports-variable/expected.js
+++ b/test/fixtures/transformation/es6-modules-system/exports-variable/expected.js
@@ -10,9 +10,9 @@ System.register([], function (_export) {
     execute: function () {
       foo = _export("foo", 1);
       foo2 = _export("foo2", function () {});
-      foo3 = _export("foo3", undefined);
+      foo3 = _export("foo3", foo3);
       foo4 = _export("foo4", 2);
-      foo5 = _export("foo5", undefined);
+      foo5 = _export("foo5", foo5);
       foo6 = _export("foo6", 3);
       foo8 = _export("foo8", function foo8() {});
       _export("foo3", foo3 = 5);


### PR DESCRIPTION
This is the last fix needed for all tests to pass in ES6 Module Loader.

It's a very convoluted circular references case, where we export a function that sets a local variable export allowing a circular references module to update the variable binding before it's initialized. In this case, the `export var varName` statement, shouldn't set the variable back to undefined when executed, but should leave it at any value it was set to.