### PR TITLE
Watcher crashes if used on file in current directory.

### DIFF
--- a/bin/6to5/dir.js
+++ b/bin/6to5/dir.js
@@ -54,7 +54,7 @@ module.exports = function (commander, filenames, opts) {
       _.each(["add", "change"], function (type) {
         watcher.on(type, function (filename) {
           // chop off the dirname plus the path separator
-          var relative = filename.slice(dirname.length + 1);
+          var relative = path.basename(filename);
 
           console.log(type, filename);
           write(filename, relative);


### PR DESCRIPTION
I you try to use `6to5` to watch a compile a file it the current working directory. e.g. `6to5 --watch --out-dir dest/ index.js`. Simple fix using the built-in [path.basename](http://nodejs.org/api/path.html#path_path_basename_p_ext).