### PR TITLE
Change getModuleName regex to only remove extenion

### DIFF
--- a/lib/6to5/transformation/modules/_default.js
+++ b/lib/6to5/transformation/modules/_default.js
@@ -171,7 +171,7 @@ DefaultFormatter.prototype.getModuleName = function () {
 
   if (!opts.keepModuleIdExtensions) {
     // remove extension
-    filenameRelative = filenameRelative.replace(/\.(.*?)$/, "");
+    filenameRelative = filenameRelative.replace(/\.(\w*?)$/, "");
   }
 
   moduleName += filenameRelative;


### PR DESCRIPTION
Given a names like: "some.module.js" and "some.other.module.js" the current regex in DefaultFormatter.prototype.getModuleName will overmatch and only return "some" as the module name in both cases.

Changing the . character class to \w will make sure it does not pick up additional sections and returns "some.module" and "some.other.module" for the names