### PR TITLE
First pass at converting identifiers/words from en-au -> en-us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,8 +333,8 @@ _Note: Gaps between patch versions are faulty/broken releases._
  * **Polish**
   * Rest parameters now allocate the array before populating.
  * **Internal**
-  * `for...in` loops have been changed to optimised `for` loops - better performance and no enumeration of protoype keys.
-  * Parts of the code generator have now been optimised thanks to [gaearon](https://github.com/gaearon).
+  * `for...in` loops have been changed to optimized `for` loops - better performance and no enumeration of protoype keys.
+  * Parts of the code generator have now been optimized thanks to [gaearon](https://github.com/gaearon).
 
 ## 2.12.3
 
@@ -357,7 +357,7 @@ _Note: Gaps between patch versions are faulty/broken releases._
  * **Bug Fix**
   * Support non-string JSX literals.
  * **New Feature**
-  * Loose mode for some transformers that enables non-spec behaviour.
+  * Loose mode for some transformers that enables non-spec behavior.
  * **Internal**
   * Uglify `--mangle sort` has been added to the build script, cutting minified scripts in half.
 
@@ -795,7 +795,7 @@ _Note: Gaps between patch versions are faulty/broken releases._
 
 ## 1.13.2
 
- * Optimise `Array.from` usage by adding a helper method.
+ * Optimize `Array.from` usage by adding a helper method.
  * Upgrade `acorn-6to5`.
 
 ## 1.13.1

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,3 @@
 # Notes
 
- * Wildcard exports/imports wont normalise if `export default` is a non-object. See [#224](https://github.com/6to5/6to5/issues/224).
+ * Wildcard exports/imports wont normalize if `export default` is a non-object. See [#224](https://github.com/6to5/6to5/issues/224).

--- a/lib/6to5/file.js
+++ b/lib/6to5/file.js
@@ -25,7 +25,7 @@ function File(opts) {
   this.data             = {};
 
   this.lastStatements   = [];
-  this.opts             = this.normaliseOptions(opts);
+  this.opts             = this.normalizeOptions(opts);
   this.ast              = {};
 
   this.buildTransformers();
@@ -88,7 +88,7 @@ File.validOptions = [
   "accept"
 ];
 
-File.prototype.normaliseOptions = function (opts) {
+File.prototype.normalizeOptions = function (opts) {
   opts = clone(opts);
 
   for (var key in opts) {
@@ -118,7 +118,7 @@ File.prototype.normaliseOptions = function (opts) {
     ast:                    true
   });
 
-  // normalise windows path separators to unix
+  // normalize windows path separators to unix
   opts.filename = opts.filename.replace(/\\/g, "/");
 
   opts.basename = path.basename(opts.filename, path.extname(opts.filename));

--- a/lib/6to5/generation/index.js
+++ b/lib/6to5/generation/index.js
@@ -24,7 +24,7 @@ function CodeGenerator(ast, opts, code) {
 
   this.comments = ast.comments || [];
   this.tokens   = ast.tokens || [];
-  this.format   = CodeGenerator.normaliseOptions(code, opts);
+  this.format   = CodeGenerator.normalizeOptions(code, opts);
   this.ast      = ast;
 
   this.whitespace = new Whitespace(this.tokens, this.comments);
@@ -39,7 +39,7 @@ each(Buffer.prototype, function (fn, key) {
   };
 });
 
-CodeGenerator.normaliseOptions = function (code, opts) {
+CodeGenerator.normalizeOptions = function (code, opts) {
   var style = "  ";
   if (code) {
     var indent = detectIndent(code).indent;

--- a/lib/6to5/register.js
+++ b/lib/6to5/register.js
@@ -131,7 +131,7 @@ var hookExtensions = function (_exts) {
 hookExtensions(util.canCompile.EXTENSIONS);
 
 module.exports = function (opts) {
-  // normalise options
+  // normalize options
   opts = opts || {};
 
   if (opts.only != null) onlyRegex = util.regexify(opts.only);

--- a/lib/6to5/transformation/index.js
+++ b/lib/6to5/transformation/index.js
@@ -14,7 +14,7 @@ function transform(code, opts) {
 }
 
 transform.fromAst = function (ast, code, opts) {
-  ast = util.normaliseAst(ast);
+  ast = util.normalizeAst(ast);
 
   var file = new File(opts);
   file.addCode(code);

--- a/lib/6to5/transformation/modules/_default.js
+++ b/lib/6to5/transformation/modules/_default.js
@@ -176,7 +176,7 @@ DefaultFormatter.prototype.getModuleName = function () {
 
   moduleName += filenameRelative;
 
-  // normalise path separators
+  // normalize path separators
   moduleName = moduleName.replace(/\\/g, "/");
 
   return moduleName;
@@ -230,7 +230,7 @@ DefaultFormatter.prototype.exportSpecifier = function (specifier, node, nodes) {
       nodes.push(this.buildExportsWildcard(ref, node));
     } else {
       if (t.isSpecifierDefault(specifier) && !this.noInteropRequire) {
-        // importing a default so we need to normalise it
+        // importing a default so we need to normalize it
         ref = t.callExpression(this.file.addHelper("interop-require"), [ref]);
       } else {
         ref = t.memberExpression(ref, t.getSpecifierId(specifier));

--- a/lib/6to5/transformation/transformer.js
+++ b/lib/6to5/transformation/transformer.js
@@ -20,12 +20,12 @@ function Transformer(key, transformer, opts) {
   this.playground        = !!transformer.playground;
   this.secondPass        = !!transformer.secondPass;
   this.optional          = !!transformer.optional;
-  this.handlers          = this.normalise(transformer);
+  this.handlers          = this.normalize(transformer);
   this.opts              = opts || {};
   this.key               = key;
 }
 
-Transformer.prototype.normalise = function (transformer) {
+Transformer.prototype.normalize = function (transformer) {
   var self = this;
 
   if (isFunction(transformer)) {

--- a/lib/6to5/transformation/transformers/es6/block-scoping.js
+++ b/lib/6to5/transformation/transformers/es6/block-scoping.js
@@ -29,7 +29,7 @@ var isVar = function (node, parent) {
   return t.isVariableDeclaration(node, { kind: "var" }) && !isLet(node, parent);
 };
 
-var standardiseLets = function (declars) {
+var standardizeLets = function (declars) {
   for (var i = 0; i < declars.length; i++) {
     delete declars[i]._let;
   }
@@ -283,7 +283,7 @@ BlockScoping.prototype.getLetReferences = function () {
   if (!this.hasLetReferences) return;
 
   // set let references to plain var references
-  standardiseLets(declarators);
+  standardizeLets(declarators);
 
   var state = {
     letReferences: this.letReferences,

--- a/lib/6to5/transformation/transformers/es6/modules.js
+++ b/lib/6to5/transformation/transformers/es6/modules.js
@@ -26,7 +26,7 @@ exports.ExportDeclaration = function (node, parent, scope, context, file) {
   var i;
 
   if (node.declaration) {
-    // make sure variable exports have an initialiser
+    // make sure variable exports have an initializer
     // this is done here to avoid duplicating it in the module formatters
     if (t.isVariableDeclaration(node.declaration)) {
       var declar = node.declaration.declarations[0];

--- a/lib/6to5/transformation/transformers/es6/properties.computed.js
+++ b/lib/6to5/transformation/transformers/es6/properties.computed.js
@@ -58,7 +58,7 @@ var spec = function (node, body, objId, initProps, file) {
   var props = node.properties;
   var prop, key;
 
-  // normalise key
+  // normalize key
 
   for (var i = 0; i < props.length; i++) {
     prop = props[i];

--- a/lib/6to5/util.js
+++ b/lib/6to5/util.js
@@ -123,7 +123,7 @@ exports.repeat = function (width, cha) {
   return result;
 };
 
-exports.normaliseAst = function (ast, comments, tokens) {
+exports.normalizeAst = function (ast, comments, tokens) {
   if (ast && ast.type === "Program") {
     return t.file(ast, comments || [], tokens || []);
   } else {
@@ -150,7 +150,7 @@ exports.parse = function (opts, code, callback) {
 
     estraverse.attachComments(ast, comments, tokens);
 
-    ast = exports.normaliseAst(ast, comments, tokens);
+    ast = exports.normalizeAst(ast, comments, tokens);
 
     if (callback) {
       return callback(ast);

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -3,7 +3,7 @@ var path = require("path");
 var fs   = require("fs");
 var _    = require("lodash");
 
-var humanise = function (val, noext) {
+var humanize = function (val, noext) {
   if (noext) val = path.basename(val, path.extname(val));
   return val.replace(/-/g, " ");
 };
@@ -37,7 +37,7 @@ exports.get = function (entryName, entryLoc) {
     var suite = {
       options: {},
       tests: [],
-      title: humanise(suiteName),
+      title: humanize(suiteName),
       filename: entryLoc + "/" + suiteName
     };
     suites.push(suite);
@@ -83,7 +83,7 @@ exports.get = function (entryName, entryLoc) {
       if (taskOptsLoc) _.merge(taskOpts, require(taskOptsLoc));
 
       var test = {
-        title: humanise(taskName, true),
+        title: humanize(taskName, true),
         disabled: taskName[0] === ".",
         options: taskOpts,
         exec: {

--- a/test/test262.js
+++ b/test/test262.js
@@ -20,7 +20,7 @@ var exec = function (loc) {
   try {
     var file = fs.readFileSync(loc, "utf8");
 
-    // this normalises syntax and early runtime reference errors since they're
+    // this normalizes syntax and early runtime reference errors since they're
     // both thrown as SyntaxErrors in acorn
     // SyntaxError: var null;
     // ReferenceError: 1++; (runtime)

--- a/test/traceur.js
+++ b/test/traceur.js
@@ -37,7 +37,7 @@ require("./_transformation-helper")({
     "Syntax/UseStrictEscapeSequence",
     "Syntax/UseStrictLineContinuation",
 
-    // experimental es7 - the spec hasn't been finalised yet
+    // experimental es7 - the spec hasn't been finalized yet
     // these both fail because of filter between blocks
     "ArrayComprehension/Simple",
     "GeneratorComprehension/Simple",


### PR DESCRIPTION
Hopefully this isn't controversial to the authors, but in my [obviously biased] experience, open source projects typically prefer to use American English for identifiers and documentation because this practice is standard in the software industry.

As trivial as it may sound at first, as this project grows and more and more people start collaborating (...hopefully), we probably don't want to have mixed dialects, which cause cause bugs or simply developer frustration in remembering the correct form.

This will likely become even more important as various [public APIs](https://github.com/6to5/6to5/issues/607) comes to fruition.

If you disagree, I won't be offended, but I think this is a natural evolution. :smiley:

For your consideration:

![MERICA](https://cdn.shopify.com/s/files/1/0417/1121/files/tumblr_mj0oa1qM0o1re204ao1_500.gif?1627)