### PR TITLE
Concatenate adjacent string literals in JSX

### DIFF
--- a/lib/6to5/transformation/transformers/other/react.js
+++ b/lib/6to5/transformation/transformers/other/react.js
@@ -5,9 +5,10 @@
 
 // jsx
 
-var esutils = require("esutils");
-var react   = require("../../helpers/react");
-var t       = require("../../../types");
+var esutils  = require("esutils");
+var isString = require("lodash/lang/isString");
+var react    = require("../../helpers/react");
+var t        = require("../../../types");
 
 exports.JSXIdentifier = function (node, parent) {
   if (node.name === "this" && t.isReferenced(node, parent)) {
@@ -185,7 +186,6 @@ var cleanJSXElementLiteralChild = function (child, args) {
 
     var isFirstLine = i === 0;
     var isLastLine = i === lines.length - 1;
-    var isLastNonEmptyLine = i === lastNonEmptyLine;
 
     // replace rendered whitespace tabs with spaces
     var trimmedLine = line.replace(/\t/g, " ");
@@ -201,11 +201,12 @@ var cleanJSXElementLiteralChild = function (child, args) {
     }
 
     if (trimmedLine) {
-      if (!isLastNonEmptyLine) {
-        trimmedLine += " ";
+      var lastArg = args[args.length - 1];
+      if (t.isLiteral(lastArg) && isString(lastArg.value)) {
+        lastArg.value += " " + trimmedLine;
+      } else {
+        args.push(t.literal(trimmedLine));
       }
-
-      args.push(t.literal(trimmedLine));
     }
   }
 };

--- a/test/fixtures/transformation/react/concatenates-adjacent-string-literals/actual.js
+++ b/test/fixtures/transformation/react/concatenates-adjacent-string-literals/actual.js
@@ -1,0 +1,13 @@
+var x =
+  <div>
+    foo
+    {'bar'}
+    baz
+    <div>
+      buz
+      bang
+    </div>
+    qux
+    {null}
+    quack
+  </div>

--- a/test/fixtures/transformation/react/concatenates-adjacent-string-literals/expected.js
+++ b/test/fixtures/transformation/react/concatenates-adjacent-string-literals/expected.js
@@ -1,0 +1,13 @@
+var x = React.createElement(
+  "div",
+  null,
+  "foo bar baz",
+  React.createElement(
+    "div",
+    null,
+    "buz bang"
+  ),
+  "qux",
+  null,
+  "quack"
+);


### PR DESCRIPTION
This takes the fix for #668 one step further by concatenating adjacent string literals, resulting in a single DOM node as it works in Facebook's transpiler.

**JSX**

```jsx
<div>
  foo
  bar
</div>
```

**Before**

```js
React.createElement(
  "div",
  null,
  "foo ",
  "bar"
);
```

which renders as

```html
<div><span>foo </span><span>bar</span></div>
```

**After**

```js
React.createElement(
  "div",
  null,
  "foo bar"
);
```

which renders as

```html
<div>foo bar</div>
```

Fewer DOM nodes is better for perf and easier to read!