### PR TITLE
Update kexec for iojs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "uglify-js": "2.4.16"
   },
   "optionalDependencies": {
-    "kexec": "1.0.0"
+    "kexec": "1.1.1"
   }
 }


### PR DESCRIPTION
Not sure what kexec is needed for but it does throw errors when installing with iojs support. Based on the `kexec` changelog `1.1.0` should fix that.