### PR TITLE
Make `__esModule` property not enumerable

### DIFF
--- a/lib/6to5/transformation/templates/exports-module-declaration.js
+++ b/lib/6to5/transformation/templates/exports-module-declaration.js
@@ -1,1 +1,3 @@
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-amd/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/exports-from/expected.js
@@ -14,5 +14,7 @@ define(["exports", "foo"], function (exports, _foo) {
   exports["default"] = _foo.foo;
   exports["default"] = _foo.foo;
   exports.bar = _foo.bar;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-amd/exports-named/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/exports-named/expected.js
@@ -8,5 +8,7 @@ define(["exports"], function (exports) {
   exports["default"] = foo;
   exports["default"] = foo;
   exports.bar = bar;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-amd/exports-variable/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/exports-variable/expected.js
@@ -17,5 +17,7 @@ define(["exports"], function (exports) {
     _classCallCheck(this, foo8);
   };
 
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-amd/hoist-function-exports/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/hoist-function-exports/expected.js
@@ -12,5 +12,7 @@ define(["exports", "./evens"], function (exports, _evens) {
       return !isEven(n);
     };
   })(isEven);
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-amd/overview/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/overview/expected.js
@@ -12,5 +12,7 @@ define(["exports", "foo", "foo-bar", "./directory/foo-bar"], function (exports, 
   var test2 = exports.test2 = 5;
 
   exports["default"] = test;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-amd/remap/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/remap/expected.js
@@ -10,5 +10,7 @@ define(["exports"], function (exports) {
     test = 3;
     test++;
   })();
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-common/exports-default-non-function/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/exports-default-non-function/expected.js
@@ -3,4 +3,6 @@
 exports.Cachier = Cachier;
 exports["default"] = new Cachier();
 function Cachier(databaseName) {}
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/exports-from/expected.js
@@ -15,4 +15,6 @@ exports.bar = _foo.foo;
 exports["default"] = _foo.foo;
 exports["default"] = _foo.foo;
 exports.bar = _foo.bar;
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/exports-named/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/exports-named/expected.js
@@ -7,4 +7,6 @@ exports.bar = foo;
 exports["default"] = foo;
 exports["default"] = foo;
 exports.bar = bar;
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/exports-variable/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/exports-variable/expected.js
@@ -16,4 +16,6 @@ var foo8 = exports.foo8 = function foo8() {
   _classCallCheck(this, foo8);
 };
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/hoist-function-exports/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/hoist-function-exports/expected.js
@@ -11,4 +11,6 @@ var isOdd = exports.isOdd = (function (isEven) {
     return !isEven(n);
   };
 })(isEven);
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/overview/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/overview/expected.js
@@ -18,4 +18,6 @@ var bar = require("foo4").bar;
 var bar2 = require("foo5").foo;
 exports.test = test;
 var test = exports.test = 5;
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-common/remap/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/remap/expected.js
@@ -9,4 +9,6 @@ test = exports.test += 1;
   test = 3;
   test++;
 })();
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/test/fixtures/transformation/es6-modules-umd/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/exports-from/expected.js
@@ -20,5 +20,7 @@
   exports["default"] = _foo.foo;
   exports["default"] = _foo.foo;
   exports.bar = _foo.bar;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-umd/exports-named/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/exports-named/expected.js
@@ -14,5 +14,7 @@
   exports["default"] = foo;
   exports["default"] = foo;
   exports.bar = bar;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-umd/exports-variable/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/exports-variable/expected.js
@@ -23,5 +23,7 @@
     _classCallCheck(this, foo8);
   };
 
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-umd/hoist-function-exports/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/hoist-function-exports/expected.js
@@ -18,5 +18,7 @@
       return !isEven(n);
     };
   })(isEven);
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-umd/overview/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/overview/expected.js
@@ -18,5 +18,7 @@
   var test2 = exports.test2 = 5;
 
   exports["default"] = test;
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/es6-modules-umd/remap/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/remap/expected.js
@@ -16,5 +16,7 @@
     test = 3;
     test++;
   })();
-  exports.__esModule = true;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
 });

--- a/test/fixtures/transformation/self-contained/full/expected.js
+++ b/test/fixtures/transformation/self-contained/full/expected.js
@@ -27,4 +27,6 @@ var foo = _to5Helpers.interopRequire(_someModule);
 var bar = _to5Helpers.interopRequireWildcard(_someModule);
 
 var myWord = exports.myWord = _core.Symbol("abc");
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});


### PR DESCRIPTION
This had been bothering me when iterating over a module's exports. For example, if I have a module like this:
```js
export function a () { ... }
export function b () { ... }
export function c () { ... }
```
And another module that consumes it like this:
```js
import * as Foo from './';
for (fn in Foo) {
  Foo[fn]();
}
```
I expect it to work, but it did not because it iterated over the `__esModule` key, causing an error here. I changed the transformation to use `defineProperty` and updated the test fixtures.