### PR TITLE
Fixes npm test jshint warnings

### DIFF
--- a/lib/6to5/transformation/transformers/es6/tail-call.js
+++ b/lib/6to5/transformation/transformers/es6/tail-call.js
@@ -2,10 +2,6 @@
 
 var t    = require("../../../types");
 
-function returnBlock(expr) {
-  return t.blockStatement([t.returnStatement(expr)]);
-}
-
 function transformExpression(node, scope, state) {
   if (!node) return;
 

--- a/lib/6to5/types/index.js
+++ b/lib/6to5/types/index.js
@@ -6,7 +6,6 @@ var isString         = require("lodash/lang/isString");
 var compact          = require("lodash/array/compact");
 var esutils          = require("esutils");
 var object           = require("../helpers/object");
-var merge            = require("lodash/object/merge");
 var Node             = require("./node");
 var each             = require("lodash/collection/each");
 var uniq             = require("lodash/array/uniq");


### PR DESCRIPTION
`npm test` fails because of these two warnings.

This commit fixes npm test and also removes the warnings from `make lint`