### PR TITLE
Do not attempt nested TCO

### DIFF
--- a/lib/6to5/transformation/templates/tail-call.js
+++ b/lib/6to5/transformation/templates/tail-call.js
@@ -10,14 +10,15 @@
   var isRunning = false;
 
   return function (func, args, context) {
-    var result = new Tail(func, args, context);
-    if (!isRunning) {
-      isRunning = true;
-      do {
-        result = result.func.apply(result.context, result.args);
-      } while (result instanceof Tail || (result && result._isTailDescriptor));
-      isRunning = false;
+    if (isRunning) {
+      return func.apply(context, args);
     }
+    var result = new Tail(func, args, context);
+    isRunning = true;
+    do {
+      result = result.func.apply(result.context, result.args);
+    } while (result instanceof Tail || (result && result._isTailDescriptor));
+    isRunning = false;
     return result;
   };
 })()


### PR DESCRIPTION
With v3.5.0 and v3.5.1, The following snippet throws when executed with `6to5-node`, but not with `6to5-node --blacklist es6.tailCall`:

```javascript
function foo() {
  return "foo";
}

function fooWrapper() {
  return foo();
}

function test() {
  var str = fooWrapper();
  if (str !== "foo") {
    throw new Error();
  }
}

function testWrapper() {
  return test();
}

testWrapper();
```

I have submitted a very simple change to fix the issue. There might be a more optimized way to do it, and I didn't add tests because I had trouble getting them to run (first time attempting to contribute to 6to5), however breaking valid code is an urgent issue so I just went ahead and created this pull request. I just saw that a few minutes ago 3.5.2 completely disabled TCO, so I guess it's not urgent anymore. :)

If you want me to add tests I'll be happy to work a bit more on it tomorrow.




