### PR TITLE
fix defaults helper in strict mode - #738

### DIFF
--- a/lib/6to5/transformation/templates/defaults.js
+++ b/lib/6to5/transformation/templates/defaults.js
@@ -2,8 +2,9 @@
   var keys = Object.getOwnPropertyNames(defaults);
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
-    if (obj[key] === undefined) {
-      Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key));
+    var value = Object.getOwnPropertyDescriptor(defaults, key);
+    if (value.configurable && obj[key] === undefined) {
+      Object.defineProperty(obj, key, value);
     }
   }
   return obj;

--- a/test/fixtures/transformation/es6-modules-amd/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-amd/exports-from/expected.js
@@ -3,7 +3,7 @@ define(["exports", "foo"], function (exports, _foo) {
 
   var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
 
-  var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+  var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
   _defaults(exports, _interopRequireWildcard(_foo));
 

--- a/test/fixtures/transformation/es6-modules-common/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-common/exports-from/expected.js
@@ -2,7 +2,7 @@
 
 var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
 
-var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
 var _foo = require("foo");
 

--- a/test/fixtures/transformation/es6-modules-umd/exports-from/expected.js
+++ b/test/fixtures/transformation/es6-modules-umd/exports-from/expected.js
@@ -9,7 +9,7 @@
 
   var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
 
-  var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+  var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
   _defaults(exports, _interopRequireWildcard(_foo));
 

--- a/test/fixtures/transformation/spec-proto-to-assign/assignment-expression/expected.js
+++ b/test/fixtures/transformation/spec-proto-to-assign/assignment-expression/expected.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _foo, _foo$bar, _foo$bar2;
-var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
 console.log((_foo = foo, _defaults(_foo, bar), _foo));
 

--- a/test/fixtures/transformation/spec-proto-to-assign/assignment-statement/expected.js
+++ b/test/fixtures/transformation/spec-proto-to-assign/assignment-statement/expected.js
@@ -1,5 +1,5 @@
 "use strict";
 
-var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
 _defaults(obj, bar);

--- a/test/fixtures/transformation/spec-proto-to-assign/class/expected.js
+++ b/test/fixtures/transformation/spec-proto-to-assign/class/expected.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; if (obj[key] === undefined) { Object.defineProperty(obj, key, Object.getOwnPropertyDescriptor(defaults, key)); } } return obj; };
+var _defaults = function (obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; };
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) _defaults(subClass, superClass); };
 


### PR DESCRIPTION
The new defaults helper that uses getOwnPropertyNames throws an exception in strict mode because `length`, `arguments`, `callee`, etc. are included from Function. Fixes this by making sure that defaults[key] is configurable, which is set to false for these properties. This should also keep the same thing happening for other builtin objects.