### PR TITLE
fixes extend when class names are the same, cf #759

### DIFF
--- a/lib/6to5/transformation/transformers/es6/classes.js
+++ b/lib/6to5/transformation/transformers/es6/classes.js
@@ -102,6 +102,8 @@ ClassTransformer.prototype.run = function () {
       var superRef = this.scope.generateUidBasedOnNode(superName, this.file);
       superName = superRef;
     }
+    if (superName.name == className.name)
+      superName = this.scope.generateUidIdentifier(superName, this.file);
 
     closureParams.push(superName);
 


### PR DESCRIPTION
I'm not sure if this is what the spec intends, couldn't find anything about it, but it works as if the old class was named something else.